### PR TITLE
fix: Ensure request ArrayBuffer body works

### DIFF
--- a/src/request-matcher.js
+++ b/src/request-matcher.js
@@ -284,6 +284,49 @@ export class RequestMatcher {
 				}
 
 				messages.push("✅ Body matches.");
+			} else if (this.#body instanceof ArrayBuffer) {
+				
+				if (!(request.body instanceof ArrayBuffer)) {
+					return {
+						matches: false,
+						messages: [
+							...messages,
+							`❌ Body does not match. Expected ArrayBuffer but received ${request.body.constructor.name}.`,
+						],
+					};
+				}
+				
+				// compare array buffers
+				if (
+					request.body.byteLength !== this.#body.byteLength
+				) {
+					return {
+						matches: false,
+						messages: [
+							...messages,
+							`❌ Body does not match. Expected array buffer byte length ${this.#body.byteLength} but received ${request.body.byteLength}`,
+						],
+					};
+				}
+				
+				// convert into uint8arrays to compare
+				const expectedBody = new Uint8Array(this.#body);
+				const actualBody = new Uint8Array(request.body);
+				
+				for (let i = 0; i < expectedBody.length; i++) {
+					if (expectedBody[i] !== actualBody[i]) {
+						return {
+							matches: false,
+							messages: [
+								...messages,
+								`❌ Body does not match. Expected byte ${i} to be ${expectedBody[i]} but received ${actualBody[i]}.`,
+							],
+						};
+					}
+				}
+
+				messages.push("✅ Body matches.");
+				
 			} else {
 				// body must be an object here to run a check
 				if (typeof request.body !== "object") {
@@ -295,7 +338,7 @@ export class RequestMatcher {
 						],
 					};
 				}
-
+console.log('hi')
 				// body is an object so proceed
 				if (!deepCompare(request.body, this.#body)) {
 					return {


### PR DESCRIPTION
This pull request introduces support for handling `ArrayBuffer` bodies in the `RequestMatcher` class and updates related tests in `tests/mock-server.test.js`. The most important changes include adding logic to compare `ArrayBuffer` bodies, updating the `createRequest` function in the tests to handle `ArrayBuffer` bodies, and adding new tests to verify the functionality.

### Enhancements to `RequestMatcher`:

* Added logic to compare `ArrayBuffer` bodies, including checks for byte length and individual byte values.
* Added a console log statement for debugging purposes.

### Updates to `createRequest` function:

* Modified `createRequest` to handle `ArrayBuffer` bodies and set the appropriate `content-type` header.

### Test improvements:

* Updated global variables to include `TextEncoder` for encoding text into `ArrayBuffer`.
* Enhanced `getResponseBody` to handle `arrayBuffer` responses.
* Added tests to verify matching and non-matching `ArrayBuffer` bodies in requests.