### PR TITLE
feat: Add ability to delay generating a response

### DIFF
--- a/docs/src/content/docs/mock-servers/extended-response-patterns.mdx
+++ b/docs/src/content/docs/mock-servers/extended-response-patterns.mdx
@@ -12,6 +12,7 @@ The following keys can be used in the response pattern object:
 -   `status` (required) - the HTTP status code to return.
 -   `headers` - HTTP headers to return with the response.
 -   `body` - the body of the response to return. This can be a string, an object (which is treated as JSON), or an `ArrayBuffer`.
+-   `delay` - the number of milliseconds to wait before returning the response.
 
 The response pattern keys are used to create a new `Response` object that is returned when the associated request pattern matches the request.
 
@@ -96,3 +97,20 @@ server.get("/users", {
 ```
 
 This route will respond to any GET request to `/users` with a status code of 200, a `Content-Type` header of `application/json`, and a JSON response body containing an `id` and `name` property.
+
+## Delaying the response
+
+If you'd like to delay the response to a request, you can use the `delay` key in the response pattern object. The `delay` property is the number of milliseconds to wait before returning the response. Here's an example:
+
+```js
+import { MockServer } from "mentoss";
+
+const server = new MockServer("https://api.example.com");
+
+server.get("/users", {
+	status: 200,
+	delay: 1000, // delay the response by 1 second
+});
+```
+
+This route will respond to any GET request to `/users` with a status code of 200, but it will wait for 1 second before returning the response.

--- a/src/fetch-mocker.js
+++ b/src/fetch-mocker.js
@@ -23,7 +23,6 @@ import {
 //-----------------------------------------------------------------------------
 
 /** @typedef {import("./types.js").RequestPattern} RequestPattern */
-/** @typedef {import("./types.js").ResponsePattern} ResponsePattern */
 /** @typedef {import("./mock-server.js").MockServer} MockServer */
 /** @typedef {import("./mock-server.js").Trace} Trace */
 
@@ -176,11 +175,11 @@ export class FetchMocker {
 			// first check to see if the request has been aborted
 			const signal = init?.signal;
 			signal?.throwIfAborted();
-			
-			// assign an event handler to listen for abort events
-			signal?.addEventListener("abort", () => {
-				throw signal?.reason ?? new Error("Fetch aborted");
-			});
+
+			// TODO: For some reason this causes Mocha tests to fail with "multiple done"
+			// signal?.addEventListener("abort", () => {
+			// 	throw new Error("Fetch was aborted.");
+			// });
 			
 			// adjust any relative URLs
 			const fixedInput =
@@ -216,11 +215,15 @@ export class FetchMocker {
 				}
 			}
 			
+			signal?.throwIfAborted();
+
 			const response = await this.#internalFetch(request, init?.body);
 
 			if (useCors && this.#baseUrl) {
 				assertCorsResponse(response, this.#baseUrl.origin);
 			}
+			
+			signal?.throwIfAborted();
 
 			return response;
 		};

--- a/src/mock-server.js
+++ b/src/mock-server.js
@@ -3,7 +3,7 @@
  * @author Nicholas C. Zakas
  */
 
-/* global Response, FormData */
+/* global Response, FormData, setTimeout */
 
 //-----------------------------------------------------------------------------
 // Imports
@@ -180,6 +180,16 @@ export class Route {
 				...init.headers,
 			},
 		});
+	}
+	
+	/**
+	 * Creates a delay as specified by the route's response pattern.
+	 * @returns {Promise<void>} A promise that resolves when the delay is over.
+	 */
+	async delay() {
+		if (this.#response.delay) {
+			await new Promise(resolve => setTimeout(resolve, this.#response.delay));
+		}
 	}
 
 	/**
@@ -377,6 +387,8 @@ export class MockServer {
 				 */
 				const response = route.createResponse(PreferredResponse);
 				Object.defineProperty(response, "url", { value: request.url });
+				
+				await route.delay();
 
 				return { response, traces };
 			}

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,24 @@ export interface RequestPattern {
 }
 
 export interface ResponsePattern {
+	
+	/**
+	 * The status code of the response.
+	 */
 	status: number;
+	
+	/**
+	 * The headers of the response.
+	 */
 	headers?: Record<string, string>;
+	
+	/**
+	 * The body of the response.
+	 */
 	body?: string | any | ArrayBuffer | null;
+	
+	/**
+	 * The number of milliseconds to delay the response by.
+	 */
+	delay?: number;
 }

--- a/tests/fetch-mocker.test.js
+++ b/tests/fetch-mocker.test.js
@@ -1039,8 +1039,7 @@ describe("FetchMocker", () => {
 			);
 		});
 		
-		// need to have delayed responses for this to work
-		it.skip("should throw an abort error when the request is aborted", async () => {
+		it("should throw an abort error when the request is aborted", async () => {
 			const server = new MockServer(BASE_URL);
 			const fetchMocker = new FetchMocker({
 				servers: [server],
@@ -1049,19 +1048,18 @@ describe("FetchMocker", () => {
 			server.get("/hello", {
 				status: 200,
 				body: "Hello world!",
+				delay: 100
 			});
 
 			const controller = new AbortController();
 
 			queueMicrotask(() => controller.abort());
 			
-			const request = fetchMocker.fetch(BASE_URL + "/hello", {
-				signal: controller.signal,
-			});
-			
 			await assert.rejects(
-				request,
-				/AbortError/,
+				fetchMocker.fetch(BASE_URL + "/hello", {
+					signal: controller.signal,
+				}),
+				/aborted/,
 			);
 		});
 		

--- a/tests/mock-server.test.js
+++ b/tests/mock-server.test.js
@@ -246,6 +246,22 @@ describe("MockServer", () => {
 			const response = await server.receive(request);
 			assert.strictEqual(response.url, `${BASE_URL}/test?foo=bar`);
 		});
+		
+		it("should delay the response by at least 500ms", async () => {
+			server.get("/test", { status: 200, body: "OK", delay: 500 });
+
+			const request = createRequest({
+				method: "GET",
+				url: `${BASE_URL}/test?foo=bar`,
+			});
+
+			const startTime = Date.now();
+			const response = await server.receive(request);
+			const elapsed = Date.now() - startTime;
+			
+			assert.ok(elapsed > 500, "Response was not delayed at least one second");
+			assert.strictEqual(response.url, `${BASE_URL}/test?foo=bar`);
+		});
 	});
 
 	describe("traceReceive()", () => {

--- a/tests/mock-server.test.js
+++ b/tests/mock-server.test.js
@@ -259,7 +259,7 @@ describe("MockServer", () => {
 			const response = await server.receive(request);
 			const elapsed = Date.now() - startTime;
 			
-			assert.ok(elapsed > 500, "Response was not delayed at least one second");
+			assert.ok(elapsed > 500, "Response was not delayed at least 500ms");
 			assert.strictEqual(response.url, `${BASE_URL}/test?foo=bar`);
 		});
 	});

--- a/tests/mock-server.test.js
+++ b/tests/mock-server.test.js
@@ -259,7 +259,7 @@ describe("MockServer", () => {
 			const response = await server.receive(request);
 			const elapsed = Date.now() - startTime;
 			
-			assert.ok(elapsed > 500, "Response was not delayed at least 500ms");
+			assert.ok(elapsed > 500, `Response was delayed ${elapsed}ms, expected at least 500ms.`);
 			assert.strictEqual(response.url, `${BASE_URL}/test?foo=bar`);
 		});
 	});

--- a/tests/mock-server.test.js
+++ b/tests/mock-server.test.js
@@ -259,7 +259,7 @@ describe("MockServer", () => {
 			const response = await server.receive(request);
 			const elapsed = Date.now() - startTime;
 			
-			assert.ok(elapsed > 500, `Response was delayed ${elapsed}ms, expected at least 500ms.`);
+			assert.ok(elapsed >= 500, `Response was delayed ${elapsed}ms, expected at least 500ms.`);
 			assert.strictEqual(response.url, `${BASE_URL}/test?foo=bar`);
 		});
 	});


### PR DESCRIPTION
This pull request introduces the ability to delay responses in the mock server and includes several related changes across the codebase. The most important changes include updates to the documentation, modifications to the `MockServer` and `Route` classes, and adjustments to the tests to account for the new delay feature.

### Documentation Updates:
* Added the `delay` key to the response pattern object in the documentation to explain how to delay responses by a specified number of milliseconds. [[1]](diffhunk://#diff-b2b70c9e8cc68f67af3f7f6832092e0c4972402451b3196650683499f7427dcaR15) [[2]](diffhunk://#diff-b2b70c9e8cc68f67af3f7f6832092e0c4972402451b3196650683499f7427dcaR100-R116)

### Codebase Modifications:
* Added the `delay` property to the `ResponsePattern` interface in `src/types.ts` to define the delay duration for responses.
* Implemented the delay functionality in the `Route` class by adding a `delay` method that creates a delay based on the response pattern.
* Updated the `MockServer` class to call the `delay` method before returning the response.

### Test Adjustments:
* Updated the test cases to include scenarios for delayed responses, ensuring the delay functionality works as expected. [[1]](diffhunk://#diff-c7749aa975a360a952d495ce66db5a38c09de5fa882d6cf00f2a86949208c1b9L1042-R1042) [[2]](diffhunk://#diff-c7749aa975a360a952d495ce66db5a38c09de5fa882d6cf00f2a86949208c1b9R1051-R1062) [[3]](diffhunk://#diff-8ea18cf1c7d7bb1ad2967a064ede011cc0f2b983f81dc73877857d6b379049dfR249-R264)

### Miscellaneous:
* Removed an unused import statement for `ResponsePattern` in `src/fetch-mocker.js`.
* Commented out an event listener for abort events in `FetchMocker` due to issues with Mocha tests.
* Added `setTimeout` to the global definitions in `src/mock-server.js` to support the delay functionality.