### PR TITLE
fix: Validate route inputs

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -71,3 +71,15 @@ export const statusTexts = new Map([
 	[510, "Not Extended"],
 	[511, "Network Authentication Required"],
 ]);
+
+export const verbs = [
+	"GET",
+	"POST",
+	"PUT",
+	"DELETE",
+	"PATCH",
+	"HEAD",
+	"OPTIONS",
+	// "CONNECT",
+	// "TRACE"
+];

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,8 @@ export interface RequestPattern {
 	body?: HttpBody;
 }
 
+export type MethodlessRequestPattern = Omit<RequestPattern, "method">;
+
 export interface ResponsePattern {
 	status: number;
 	headers?: Record<string, string>;


### PR DESCRIPTION
This pull request includes various updates to the `MockServer` class and related files to improve input validation both at runtime and at development time. The most important changes include the addition of new validation functions, updates to route methods to use methodless request pattern types, and enhancements to the test suite. This ensures that both request and response patterns are valid before registering them.

### Input validation improvements:

* [`src/mock-server.js`](diffhunk://#diff-5024b7448f56bf978cf6ef5e933780ebabaf2d2977e6650c3c4df42c484245c4R75-R124): Added `assertNoMethod` and `assertValidResponsePattern` functions to validate request patterns without methods and response patterns, respectively.
* [`src/mock-server.js`](diffhunk://#diff-5024b7448f56bf978cf6ef5e933780ebabaf2d2977e6650c3c4df42c484245c4L40-R41): Modified `assertValidRequestPattern` to be a private function.

### Support for methodless request patterns:

* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR17-R18): Introduced `MethodlessRequestPattern` type, which omits the `method` property from `RequestPattern`.
* [`src/mock-server.js`](diffhunk://#diff-5024b7448f56bf978cf6ef5e933780ebabaf2d2977e6650c3c4df42c484245c4L269-R392): Updated route methods (`post`, `get`, `put`, `delete`, `patch`, `head`, `options`) to use `MethodlessRequestPattern` and validate that the request pattern does not include a method.

### Enhancements to route handling:

* [`src/mock-server.js`](diffhunk://#diff-5024b7448f56bf978cf6ef5e933780ebabaf2d2977e6650c3c4df42c484245c4L241-R306): Ensured that request and response patterns are validated before adding routes.

### Test suite enhancements:

* [`tests/mock-server.test.js`](diffhunk://#diff-8ea18cf1c7d7bb1ad2967a064ede011cc0f2b983f81dc73877857d6b379049dfL1001-R1102): Added new tests to validate the absence of methods in methodless request patterns and the correctness of response patterns.
* [`tests/mock-server.test.js`](diffhunk://#diff-8ea18cf1c7d7bb1ad2967a064ede011cc0f2b983f81dc73877857d6b379049dfL13-R22): Imported `verbs` from `src/http.js` for use in test cases.

### Additional changes:

* [`src/http.js`](diffhunk://#diff-9097bfe5ae868eccdb921b5a043bd3bc4087e8aacd257640ab51f1513baae7b4R74-R85): Added an export for HTTP verbs.