### PR TITLE
feat: Add test helper methods

### DIFF
--- a/docs/src/content/docs/fetch-mockers/testing-helpers-fetch-mocker.mdx
+++ b/docs/src/content/docs/fetch-mockers/testing-helpers-fetch-mocker.mdx
@@ -1,0 +1,146 @@
+---
+title: "Testing Helpers: Fetch Mocker"
+description: The fetch mocker methods that are helpful for testing.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+The fetch mocker provides several methods to help verify that your requests were made as expected.
+
+## Verifying Route Calls
+
+Tracking which routes have been called is a key part of many tests. The fetch mocker provides several methods and properties to help with this.
+
+### `allRoutesCalled()`
+
+The `allRoutesCalled()` method checks if all routes have been called on all servers. It returns `true` if all routes have been called at least once, and `false` otherwise:
+
+```js {10, 13, 16}
+import { MockServer, FetchMocker } from "mentoss";
+
+const server1 = new MockServer("https://api1.example.com");
+const server2 = new MockServer("https://api2.example.com");
+const mocker = new FetchMocker({ servers: [server1, server2] });
+
+server1.get("/users", 200);
+server2.post("/users", 200);
+
+console.log(mocker.allRoutesCalled()); // false
+
+await mocker.fetch("https://api1.example.com/users");
+console.log(mocker.allRoutesCalled()); // false
+
+await mocker.fetch("https://api2.example.com/users", { method: "POST" });
+console.log(mocker.allRoutesCalled()); // true
+```
+
+In this example, the `allRoutesCalled()` method first returns `false` because neither the GET nor the POST `/users` route has been called yet. After both routes have been called, the method returns `true`.
+
+### `assertAllRoutesCalled()`
+
+The `assertAllRoutesCalled()` method is an assertion that checks if all routes have been called. It throws an error if any routes have not been called:
+
+```js {11}
+import { MockServer, FetchMocker } from "mentoss";
+
+const server1 = new MockServer("https://api1.example.com");
+const server2 = new MockServer("https://api2.example.com");
+const mocker = new FetchMocker({ servers: [server1, server2] });
+
+server1.get("/users", 200);
+server2.post("/users", 200);
+
+await mocker.fetch("https://api1.example.com/users");
+server.assertAllRoutesCalled(); // Error!
+```
+
+The thrown error contains a message with information about the uncalled routes.
+
+### `called()`
+
+The `called()` method checks if a specific route has been called. You can pass either a URL string (which defaults to a GET request) or a request pattern object:
+
+```js {17,26, 28-34}
+import { MockServer, FetchMocker } from "mentoss";
+
+const server1 = new MockServer("https://api1.example.com");
+const server2 = new MockServer("https://api2.example.com");
+const mocker = new FetchMocker({ servers: [server1, server2] });
+
+server1.post(
+	{
+		url: "/users",
+		body: {
+			name: "John Doe",
+		},
+	},
+	200,
+);
+
+console.log(mocker.called("https://api1.example.com/users")); // false
+
+await mocker.fetch("https://api1.example.com/users", {
+    method: "POST",
+    body: {
+        name: "John Doe",
+    },
+});
+
+console.log(mocker.called("https://api1.example.com/users")); // true
+
+console.log(mocker.called({
+    url: "https://api1.example.com/users",
+    method: "POST",
+    body: {
+        name: "John Doe",
+    },
+})); // true
+```
+
+In this example, the `called()` method returns `false` because the `/users` route has not been called yet. The matching is done using the same comparison logic as if a `fetch()` request was made to the route.
+
+### `uncalledRoutes`
+
+The `uncalledRoutes` property returns an array with information about uncalled routes. You can use this property to check if any routes have not been called:
+
+```js {12}
+import { MockServer, FetchMocker } from "mentoss";
+
+const server1 = new MockServer("https://api1.example.com");
+const server2 = new MockServer("https://api2.example.com");
+const mocker = new FetchMocker({ servers: [server1, server2] });
+
+server1.get("/users", 200);
+server2.post("/users", 200);
+
+await mocker.fetch("https://api1.example.com/users");
+
+console.log(mocker.uncalledRoutes); // ["🚧 [Route: POST https://api2.example.com/users -> 200]"]
+```
+
+The `uncalledRoutes` property is helpful when you want to format your own error messages or assertions.
+
+<Aside type="tip">
+The `MockServer` class also supports `allRoutesCalled()`, `assertAllRoutesCalled()`, and `called()` methods, as well as the `uncalledRoutes` property. These methods and property work similarly to the `FetchMocker` equivalents except they only check routes on the given server.
+</Aside>
+
+## Additional Helpers
+
+### `clearAll()`
+
+The `clearAll()` method removes all routes from all servers so you can reuse the same server for multiple tests.
+
+```js {10}
+import { MockServer, FetchMocker } from "mentoss";
+
+const server1 = new MockServer("https://api1.example.com");
+const server2 = new MockServer("https://api2.example.com");
+const mocker = new FetchMocker({ servers: [server1, server2] });
+
+server1.get("/users", 200);
+server2.post("/users", 200);
+
+mocker.clearAll();
+
+await mocker.fetch("https://api1.example.com/users"); // Error!
+```

--- a/docs/src/content/docs/mock-servers/testing-helpers-mock-server.mdx
+++ b/docs/src/content/docs/mock-servers/testing-helpers-mock-server.mdx
@@ -1,0 +1,144 @@
+---
+title: "Testing Helpers: Mock Server"
+description: The mock server methods that are helpful for testing.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+The mock server provides several methods to help verify that your requests were made as expected.
+
+## Verifying Route Calls
+
+Tracking which routes have been called is a key part of many tests. The mock server provides several methods and properties to help with this.
+
+### `allRoutesCalled()`
+
+The `allRoutesCalled()` method checks if all routes have been called. It returns `true` if all routes have been called at least once, and `false` otherwise:
+
+```js {9, 12, 15}
+import { MockServer, FetchMocker } from "mentoss";
+
+const server = new MockServer("https://api.example.com");
+const mocker = new FetchMocker({ servers: [server] });
+
+server.get("/users", 200);
+server.post("/users", 200);
+
+console.log(server.allRoutesCalled()); // false
+
+await mocker.fetch("https://api.example.com/users");
+console.log(server.allRoutesCalled()); // false
+
+await mocker.fetch("https://api.example.com/users", { method: "POST" });
+console.log(server.allRoutesCalled()); // true
+```
+
+In this example, the `allRoutesCalled()` method first returns `false` because neither the GET nor the POST `/users` route has been called yet. After both routes have been called, the method returns `true`.
+
+### `assertAllRoutesCalled()`
+
+The `assertAllRoutesCalled()` method is an assertion that checks if all routes have been called. It throws an error if any routes have not been called:
+
+```js {10}
+import { MockServer, FetchMocker } from "mentoss";
+
+const server = new MockServer("https://api.example.com");
+const mocker = new FetchMocker({ servers: [server] });
+
+server.get("/users", 200);
+server.post("/users", 200);
+
+await mocker.fetch("https://api.example.com/users");
+server.assertAllRoutesCalled(); // Error!
+```
+
+The thrown error contains a message with information about the uncalled routes.
+
+### `called()`
+
+The `called()` method checks if a specific route has been called. You can pass either a URL string (which defaults to a GET request) or a request pattern object:
+
+```js {16,25, 27-33}
+import { MockServer, FetchMocker } from "mentoss";
+
+const server = new MockServer("https://api.example.com");
+const mocker = new FetchMocker({ servers: [server] });
+
+server.post(
+	{
+		url: "/users",
+		body: {
+			name: "John Doe",
+		},
+	},
+	200,
+);
+
+console.log(server.called("/users")); // false
+
+await mocker.fetch("https://api.example.com/users", {
+    method: "POST",
+    body: {
+        name: "John Doe",
+    },
+});
+
+console.log(server.called("/users")); // true
+
+console.log(server.called({
+    url: "/users",
+    method: "POST",
+    body: {
+        name: "John Doe",
+    },
+})); // true
+```
+
+In this example, the `called()` method returns `false` because the `/users` route has not been called yet. The matching is done using the same comparison logic as if a `fetch()` request was made to the route.
+
+### `uncalledRoutes`
+
+The `uncalledRoutes` property returns an array with information about uncalled routes. You can use this property to check if any routes have not been called:
+
+```js {11}
+import { MockServer, FetchMocker } from "mentoss";
+
+const server = new MockServer("https://api.example.com");
+const mocker = new FetchMocker({ servers: [server] });
+
+server.get("/users", 200);
+server.post("/users", 200);
+
+await mocker.fetch("https://api.example.com/users");
+
+console.log(server.uncalledRoutes); // ["🚧 [Route: POST https://api.example.com/users -> 200]"]
+```
+
+The `uncalledRoutes` property is helpful when you want to format your own error messages or assertions.
+
+<Aside type="tip">
+The `FetchMocker` class also supports `allRoutesCalled()`, `assertAllRoutesCalled()`, and `called()` methods, as well as the `uncalledRoutes` property. These methods and property work similarly to the `MockServer` methods, but they check if the routes have been called on all servers.
+</Aside>
+
+## Additional Helpers
+
+### `clear()`
+
+The `clear()` method removes all routes from the server so you can reuse the same server for multiple tests.
+
+```js {8}
+import { MockServer, FetchMocker } from "mentoss";
+
+const server = new MockServer("https://api.example.com");
+const mocker = new FetchMocker({ servers: [server] });
+
+server.get("/users", 200);
+
+server.clear();
+
+await mocker.fetch("https://api.example.com/users"); // Error!
+```
+
+<Aside type="note">
+The `FetchMocker#clearAll()` method calls `clear()` on each registered server.
+</Aside>

--- a/src/fetch-mocker.js
+++ b/src/fetch-mocker.js
@@ -50,7 +50,7 @@ Partial matches:
 ${
 	traces
 		.map(trace => {
-			let traceMessage = `🚧 ${trace.route.toString()}:`;
+			let traceMessage = `${trace.title}:`;
 
 			trace.messages.forEach(message => {
 				traceMessage += `\n  ${message}`;
@@ -337,6 +337,8 @@ export class FetchMocker {
 		return preflightData;
 	}
 
+	// #region: Testing Helpers
+	
 	/**
 	 * Determines if a request was made.
 	 * @param {string|RequestPattern} request The request to match.
@@ -358,7 +360,34 @@ export class FetchMocker {
 	allRoutesCalled() {
 		return this.#servers.every(server => server.allRoutesCalled());
 	}
+	
+	/**
+	 * Gets the uncalled routes.
+	 * @return {string[]} The uncalled routes.
+	 */
+	get uncalledRoutes() {
+		return this.#servers.flatMap(server => server.uncalledRoutes);
+	}
+	
+	/**
+	 * Asserts that all routes were called.
+	 * @returns {void}
+	 * @throws {Error} When not all routes were called.
+	 */
+	assertAllRoutesCalled() {
+		const uncalledRoutes = this.uncalledRoutes;
+		
+		if (uncalledRoutes.length > 0) {
+			throw new Error(
+				`Not all routes were called. Uncalled routes:\n${uncalledRoutes.join(
+					"\n",
+				)}`,
+			);
+		}
+	}
 
+	// #endregion: Testing Helpers
+	
 	/**
 	 * Unmocks the global fetch function.
 	 * @returns {void}


### PR DESCRIPTION
This pull request introduces new testing helpers for the `FetchMocker` and `MockServer` classes, as well as updates to their documentation. The most important changes include the addition of methods to verify route calls, check for uncalled routes, and clear routes for reuse in tests. Additionally, there are several updates and new tests to ensure the functionality of these helpers.

### Documentation Updates:
* Added new documentation files for `FetchMocker` and `MockServer` testing helpers, detailing methods such as `allRoutesCalled`, `assertAllRoutesCalled`, `called`, `uncalledRoutes`, and `clearAll` (`docs/src/content/docs/fetch-mockers/testing-helpers-fetch-mocker.mdx` [[1]](diffhunk://#diff-d55e5a2d1819ef409603f373660be06cd5a4fc29a7e3d8d7124ccfe5a336fea6R1-R146) `docs/src/content/docs/mock-servers/testing-helpers-mock-server.mdx` [[2]](diffhunk://#diff-20aab3f9b208d7a6a185ddce12696db513d2bc74adba9dbfc2254d413f352aafR1-R144).

### Code Enhancements:
* Introduced new methods in `FetchMocker` to check for uncalled routes and assert that all routes have been called (`src/fetch-mocker.js` [[1]](diffhunk://#diff-09d3018654f9d696c2ce0a5938eb9b5dd6adb822704efafcbfde8b6342f246c5R364-R390) [[2]](diffhunk://#diff-09d3018654f9d696c2ce0a5938eb9b5dd6adb822704efafcbfde8b6342f246c5R340-R341).
* Updated `MockServer` class to include methods for retrieving uncalled routes and asserting all routes have been called (`src/mock-server.js` [[1]](diffhunk://#diff-5024b7448f56bf978cf6ef5e933780ebabaf2d2977e6650c3c4df42c484245c4L273-R279) [[2]](diffhunk://#diff-5024b7448f56bf978cf6ef5e933780ebabaf2d2977e6650c3c4df42c484245c4R296-R314).

### Testing:
* Added new test cases to ensure the proper functionality of the `uncalledRoutes` and `assertAllRoutesCalled` methods in `FetchMocker` (`tests/fetch-mocker.test.js` [tests/fetch-mocker.test.jsR406-R529](diffhunk://#diff-c7749aa975a360a952d495ce66db5a38c09de5fa882d6cf00f2a86949208c1b9R406-R529)).
* Updated existing tests to reflect changes in route matching and title properties (`tests/mock-server.test.js` [[1]](diffhunk://#diff-8ea18cf1c7d7bb1ad2967a064ede011cc0f2b983f81dc73877857d6b379049dfL299-R300) [[2]](diffhunk://#diff-8ea18cf1c7d7bb1ad2967a064ede011cc0f2b983f81dc73877857d6b379049dfL320-R321).

### Refactoring:
* Refactored internal route handling in `MockServer` to use a single `#routes` array and `WeakSet` for matched routes (`src/mock-server.js` [[1]](diffhunk://#diff-5024b7448f56bf978cf6ef5e933780ebabaf2d2977e6650c3c4df42c484245c4L273-R279) [[2]](diffhunk://#diff-5024b7448f56bf978cf6ef5e933780ebabaf2d2977e6650c3c4df42c484245c4L319-R338).
* Updated trace messages to use the `title` property instead of the `route` property (`src/fetch-mocker.js` [[1]](diffhunk://#diff-09d3018654f9d696c2ce0a5938eb9b5dd6adb822704efafcbfde8b6342f246c5L53-R53) `src/mock-server.js` [[2]](diffhunk://#diff-5024b7448f56bf978cf6ef5e933780ebabaf2d2977e6650c3c4df42c484245c4L257-R257).