### PR TITLE
feat: Mocking credentialed requests

### DIFF
--- a/bun.js
+++ b/bun.js
@@ -1,0 +1,3 @@
+const request = new Request("https://example.com", { credentials: "include" });
+
+console.log(request.credentials); // "same-origin"

--- a/bun.js
+++ b/bun.js
@@ -1,3 +1,0 @@
-const request = new Request("https://example.com", { credentials: "include" });
-
-console.log(request.credentials); // "same-origin"

--- a/docs/src/content/docs/fetch-mockers/mocking-browser-requests.mdx
+++ b/docs/src/content/docs/fetch-mockers/mocking-browser-requests.mdx
@@ -13,7 +13,7 @@ Perhaps the most significant difference between using `fetch()` in a browser as 
 
 If you try to use a relative URL with `fetch()` in a server-side environment, you'll get an error. This is because the server doesn't know what the base URL should be, so it can't resolve the relative URL. That means the same `fetch()` call that works in the browser won't work in a server environment and it's important to keep that in mind when writing tests.
 
-## Mocking Browser Requests with Mentoss
+## Mock Browser Requests with Mentoss
 
 Mentoss provides a way to mock browser requests in your tests, allowing you to test code that uses `fetch()` without making actual network requests. To mock a browser request, you can provide a `baseUrl` option to the `FetchMocker` constructor. This option specifies the base URL that relative URLs should be resolved against. You can then call a mocked `fetch()` using a relative URL. Here's an example:
 
@@ -59,167 +59,177 @@ In this example, the `baseUrl` option is set to `"https://api.example.com"`, whi
 	defined for the base URL, the request will fail.
 </Aside>
 
-## Mocking CORS Requests
 
-Another important consideration when mocking browser requests is how to handle CORS (Cross-Origin Resource Sharing) requests. CORS is a security feature that restricts which domains can make requests to a server. When you make a request from one domain to another, the server must include the appropriate CORS headers to allow the request to go through. When you set the `baseUrl` option in the `FetchMocker` constructor, Mentoss automatically includes the appropriate CORS headers when a request is made to a different origin.
+## Mock Credentialed Requests
 
-### Simple Requests
+A common use case for browser requests is to include credentials, such as cookies or HTTP authentication, with the request. This is often necessary for making authenticated requests to APIs. Mentoss provides a way to mock these credentialed requests using the `credentials` option in the `FetchMocker` constructor. This option allows you to specify a list of credentials that should be included with each request. 
 
-For [simple requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests), Mentoss automatically includes the `Origin` header on the request. If the server responds with the appropriate `Access-Control-Allow-Origin` header, your code will receive the response as expected. If the server does not respond with the appropriate header, the request will fail. Here's an example:
+The `CookieCredentials` class allows you to mock cookie-based authentication in your tests. This is useful when testing applications that use cookies for maintaining session state or authentication.
 
-```js {19-21}
-import { MockServer, FetchMocker } from "mentoss";
+<Aside type="caution">
+	The `credentials` option must be used with `baseUrl`. There is no way for Mentoss to know which credentials to include with a request if the base URL is not set.
+</Aside>
 
-const BASE_URL = "https://api.example.com";
+### Create a `CookieCredentials` Instance
 
-describe("My API", () => {
-	const server = new MockServer("https://www.example.com");
-	const mocker = new FetchMocker({
-		servers: [server],
-		baseUrl: BASE_URL,
-	});
+You can create a new `CookieCredentials` instance either with or without a base URL:
 
-	// extract the fetch function
-	const myFetch = mocker.fetch;
+```js
+import { CookieCredentials } from "mentoss";
 
-	it("should return a 200 status code", async () => {
-		// set up the route to test
-		server.get("/ping", {
-			status: 200,
-			headers: {
-				"Access-Control-Allow-Origin": BASE_URL,
-			},
-			body: { message: "pong" },
-		});
+// Create credentials for a specific domain
+const credentials = new CookieCredentials("https://example.com");
 
-		// make the request
-		const response = await myFetch("https://www.example.com/ping");
+// Or create credentials without a domain
+const genericCredentials = new CookieCredentials();
+```
 
-		// check the response
-		expect(response.status).to.equal(200);
-	});
+When you create credentials with a base URL, all cookies will be automatically associated with that domain. Without a base URL, you'll need to specify the domain for each cookie.
+
+### Setting Cookies
+
+You can set cookies using the `setCookie()` method. Each cookie requires at least a name and value:
+
+```js
+// With a base URL
+const credentials = new CookieCredentials("https://example.com");
+credentials.setCookie({
+    name: "sessionId",
+    value: "abc123"
+});
+
+// Without a base URL
+const genericCredentials = new CookieCredentials();
+genericCredentials.setCookie({
+    name: "sessionId",
+    value: "abc123",
+    domain: "example.com"  // domain is required when no base URL is set
 });
 ```
 
-In this example, the server responds with the `Access-Control-Allow-Origin` header set to the base URL `"https://api.example.com"`. This allows the request to go through because the origin matches the origin of the fetch mocker's `baseUrl`, and the test passes.
+You can also specify additional cookie attributes:
 
-### Preflighted Requests
-
-For [preflighted requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests), Mentoss automatically sends an `OPTIONS` request to the server to check if the request is allowed. If the server responds with the appropriate `Access-Control-Allow-Methods` and `Access-Control-Allow-Headers` headers, the original request will go through. If the server does not respond with the appropriate headers, the request will fail. Here's an example:
-
-```js {16-23}
-import { MockServer, FetchMocker } from "mentoss";
-
-const BASE_URL = "https://api.example.com";
-
-describe("My API", () => {
-	const server = new MockServer("https://www.example.com");
-	const mocker = new FetchMocker({
-		servers: [server],
-		baseUrl: BASE_URL,
-	});
-
-	// extract the fetch function
-	const myFetch = mocker.fetch;
-
-	it("should return a 200 status code", async () => {
-		// this is for the preflight request
-		server.options("/ping", {
-			status: 200,
-			headers: {
-				"Access-Control-Allow-Origin": BASE_URL,
-				"Access-Control-Allow-Headers": "Content-Type",
-			},
-		});
-
-		// this is the route that we want to call
-		server.get("/ping", {
-			status: 200,
-			headers: {
-				"Access-Control-Allow-Origin": BASE_URL,
-			},
-			body: { message: "pong" },
-		});
-
-		// make the request
-		const response = await myFetch("https://www.example.com/ping", {
-			headers: {
-				"Content-Type": "application/json",
-			},
-		});
-
-		// check the response
-		expect(response.status).to.equal(200);
-	});
-});
-```
-
-In this example, the code attempts a request to `"https://www.example.com/ping"`. Because this is a cross-origin request, Mentoss first sends an `OPTIONS` request to the server to check if the request is allowed. The server responds to the preflight request with the appropriate `Access-Control-Allow-Origin` and `Access-Control-Allow-Headers` headers, allowing the original request to go through.
-
-### The Preflight Cache
-
-When a browser makes a preflight request, it caches the response for a period of time (usually 5 minutes but customizable using the `Access-Control-Max-Age` header). This means that if you make the same request again within the cache period, the browser won't send another preflight request. Instead, it will use the cached response to determine if the request is allowed. Mentoss does not currently support caching preflight responses, so each preflight request will result in a new preflight request to the server.
-
-Mentoss caches preflight responses in memory for the duration of the test run. This means that if you make the same preflighted request multiple times within a single test, Mentoss will only send the `OPTIONS` request once. However, you can manually clear the preflight cache by calling the `clearPreflightCache()` method. It's helpful to do this after each test
-
-```js {15-18}
-import { MockServer, FetchMocker } from "mentoss";
-
-const BASE_URL = "https://api.example.com";
-
-describe("My API", () => {
-	const server = new MockServer("https://www.example.com");
-	const mocker = new FetchMocker({
-		servers: [server],
-		baseUrl: BASE_URL,
-	});
-
-	// extract the fetch function
-	const myFetch = mocker.fetch;
-
-	// clear preflight cache entries
-	afterEach(() => {
-		mocker.clearPreflightCache();
-	});
-
-	it("should return a 200 status code", async () => {
-		// this is for the preflight request
-		server.options("/ping", {
-			status: 200,
-			headers: {
-				"Access-Control-Allow-Origin": BASE_URL,
-				"Access-Control-Allow-Headers": "Content-Type",
-			},
-		});
-
-		// this is the route that we want to call
-		server.get("/ping", {
-			status: 200,
-			headers: {
-				"Access-Control-Allow-Origin": BASE_URL,
-			},
-			body: { message: "pong" },
-		});
-
-		// make the request
-		const response = await myFetch("https://www.example.com/ping", {
-			headers: {
-				"Content-Type": "application/json",
-			},
-		});
-
-		// check the response
-		expect(response.status).to.equal(200);
-	});
+```js
+credentials.setCookie({
+    name: "sessionId",
+    value: "abc123",
+    path: "/admin",      // defaults to "/"
+    secure: true,        // defaults to false
+    httpOnly: true       // defaults to false
 });
 ```
 
 <Aside type="tip">
-	The preflight cache is also cleared when you call `mocker.clearAll()`, so
-	you don't need to call `mocker.clearPreflightCache()` if you're already
-	calling `mocker.clearAll()`.
+    The path attribute determines which paths can access the cookie. A cookie with a path of `/admin` will only be sent for requests to `/admin` and its subdirectories.
+</Aside>
+<Aside type="note">
+	Real cookies also allow you to specify an expiration date and the `HttpOnly` flag, but neither is useful for testing purposes and so are not supported.
 </Aside>
 
+### Delete Cookies
+
+To delete a cookie, use the `deleteCookie()` method with the same information used to set it:
+
+```js
+credentials.deleteCookie({
+    name: "sessionId",
+    value: "abc123"
+});
+```
+
+If you included a `domain` or `path` when setting the cookie, you must include it when deleting the cookie as well, as in this example:
+
+```js
+credentials.deleteCookie({
+	name: "sessionId",
+	value: "abc123",
+	domain: "example.com",
+});
+```
+
+### Use `CookieCredentials` with `FetchMocker`
+
+The `CookieCredentials` class is designed to work with `FetchMocker` for testing authenticated requests. When provided, `FetchMocker` will automatically include the specified cookies in requests to matching domains and paths, simulating a real browser environment. Here's a complete example:
+
+```js
+import { MockServer, FetchMocker, CookieCredentials } from "mentoss";
+
+const BASE_URL = "https://example.com";
+
+describe("Authenticated API", () => {
+    const server = new MockServer(BASE_URL);
+    const credentials = new CookieCredentials(BASE_URL);
+    const mocker = new FetchMocker({
+        servers: [server],
+        credentials: [credentials],
+		baseUrl: BASE_URL,
+    });
+
+    beforeEach(() => {
+        // Set up authentication cookie
+        credentials.setCookie({
+            name: "sessionId",
+            value: "abc123"
+        });
+    });
+
+    afterEach(() => {
+        mocker.clearAll();
+    });
+
+    it("should make authenticated request", async () => {
+        server.get({
+			url: "/api/data",
+			headers: {
+				Cookie: "sessionId=abc123"
+			}
+		}, {
+            status: 200,
+            body: { message: "success" }
+        });
+
+        const response = await mocker.fetch("/api/data");
+        expect(response.status).to.equal(200);
+    });
+});
+```
+
+In this example, the cookie will be automatically included in all requests to `example.com`.
+
+### Cookie Matching Rules
+
+Cookies are included in requests based on these rules:
+
+1. The request domain must match or be a subdomain of the cookie's domain
+2. The request path must match or be under the cookie's path
+3. For secure cookies, the request must use HTTPS
+
+For example:
+
+```js
+const credentials = new CookieCredentials("https://example.com");
+
+// Set a secure cookie for /admin path
+credentials.setCookie({
+    name: "adminSession",
+    value: "xyz789",
+    path: "/admin",
+    secure: true
+});
+
+// Will include cookie (matches domain, path, and protocol)
+await fetch("https://example.com/admin/users");
+
+// Won't include cookie (wrong protocol)
+await fetch("http://example.com/admin/users");
+
+// Won't include cookie (wrong path)
+await fetch("https://example.com/user/profile");
+
+// Will include cookie (subdomain is allowed)
+await fetch("https://sub.example.com/admin/users");
+```
+
 <Aside type="caution">
-While CORS support is mostly complete, credentialed requests (requests that include cookies or HTTP authentication information) are not yet supported. Mentoss throws an error if you try to use a credentialed request.
+    Make sure to clear credentials between tests using `mocker.clearAll()` to prevent test interference.
 </Aside>

--- a/docs/src/content/docs/fetch-mockers/mocking-browser-requests.mdx
+++ b/docs/src/content/docs/fetch-mockers/mocking-browser-requests.mdx
@@ -119,21 +119,21 @@ credentials.setCookie({
 });
 ```
 
-<Aside type="tip">
-    The path attribute determines which paths can access the cookie. A cookie with a path of `/admin` will only be sent for requests to `/admin` and its subdirectories.
-</Aside>
 <Aside type="note">
 	Real cookies also allow you to specify an expiration date and the `HttpOnly` flag, but neither is useful for testing purposes and so are not supported.
 </Aside>
 
+<Aside type="caution">
+If you called `setCookie()` multiple times with the same cookie name, domain, path, and secure flag, an error will be thrown. This is to prevent you from accidentally changing the value of a cookie. If you want to update a cookie's value, you should call `deleteCookie()` first.
+</Aside>
+
 ### Delete Cookies
 
-To delete a cookie, use the `deleteCookie()` method with the same information used to set it:
+To delete a cookie, use the `deleteCookie()` method with the same information used to set it (except for the value):
 
 ```js
 credentials.deleteCookie({
     name: "sessionId",
-    value: "abc123"
 });
 ```
 
@@ -142,7 +142,6 @@ If you included a `domain` or `path` when setting the cookie, you must include i
 ```js
 credentials.deleteCookie({
 	name: "sessionId",
-	value: "abc123",
 	domain: "example.com",
 });
 ```

--- a/docs/src/content/docs/fetch-mockers/mocking-cors-requests.mdx
+++ b/docs/src/content/docs/fetch-mockers/mocking-cors-requests.mdx
@@ -1,0 +1,276 @@
+---
+title: Mocking CORS Requests
+description: Learn how to mock browser CORS requests using Mentoss
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+Another important consideration when mocking browser requests is how to handle CORS (Cross-Origin Resource Sharing) requests. CORS is a security feature that restricts which domains can make requests to a server. When you make a request from one domain to another, the server must include the appropriate CORS headers to allow the request to go through. When you set the `baseUrl` option in the `FetchMocker` constructor, Mentoss automatically includes the appropriate CORS headers when a request is made to a different origin.
+
+## Simple Requests
+
+For [simple requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests), Mentoss automatically includes the `Origin` header on the request. If the server responds with the appropriate `Access-Control-Allow-Origin` header, your code will receive the response as expected. If the server does not respond with the appropriate header, the request will fail. Here's an example:
+
+```js {19-21}
+import { MockServer, FetchMocker } from "mentoss";
+
+const BASE_URL = "https://api.example.com";
+
+describe("My API", () => {
+	const server = new MockServer("https://www.example.com");
+	const mocker = new FetchMocker({
+		servers: [server],
+		baseUrl: BASE_URL,
+	});
+
+	// extract the fetch function
+	const myFetch = mocker.fetch;
+
+	it("should return a 200 status code", async () => {
+		// set up the route to test
+		server.get("/ping", {
+			status: 200,
+			headers: {
+				"Access-Control-Allow-Origin": BASE_URL,
+			},
+			body: { message: "pong" },
+		});
+
+		// make the request
+		const response = await myFetch("https://www.example.com/ping");
+
+		// check the response
+		expect(response.status).to.equal(200);
+	});
+});
+```
+
+In this example, the server responds with the `Access-Control-Allow-Origin` header set to the base URL `"https://api.example.com"`. This allows the request to go through because the origin matches the origin of the fetch mocker's `baseUrl`, and the test passes.
+
+## Preflighted Requests
+
+For [preflighted requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests), Mentoss automatically sends an `OPTIONS` request to the server to check if the request is allowed. If the server responds with the appropriate `Access-Control-Allow-Methods` and `Access-Control-Allow-Headers` headers, the original request will go through. If the server does not respond with the appropriate headers, the request will fail. Here's an example:
+
+```js {16-23}
+import { MockServer, FetchMocker } from "mentoss";
+
+const BASE_URL = "https://api.example.com";
+
+describe("My API", () => {
+	const server = new MockServer("https://www.example.com");
+	const mocker = new FetchMocker({
+		servers: [server],
+		baseUrl: BASE_URL,
+	});
+
+	// extract the fetch function
+	const myFetch = mocker.fetch;
+
+	it("should return a 200 status code", async () => {
+		// this is for the preflight request
+		server.options("/ping", {
+			status: 200,
+			headers: {
+				"Access-Control-Allow-Origin": BASE_URL,
+				"Access-Control-Allow-Headers": "Content-Type",
+			},
+		});
+
+		// this is the route that we want to call
+		server.get("/ping", {
+			status: 200,
+			headers: {
+				"Access-Control-Allow-Origin": BASE_URL,
+			},
+			body: { message: "pong" },
+		});
+
+		// make the request
+		const response = await myFetch("https://www.example.com/ping", {
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+
+		// check the response
+		expect(response.status).to.equal(200);
+	});
+});
+```
+
+In this example, the code attempts a request to `"https://www.example.com/ping"`. Because this is a cross-origin request, Mentoss first sends an `OPTIONS` request to the server to check if the request is allowed. The server responds to the preflight request with the appropriate `Access-Control-Allow-Origin` and `Access-Control-Allow-Headers` headers, allowing the original request to go through.
+
+## The Preflight Cache
+
+When a browser makes a preflight request, it caches the response for a period of time (usually 5 minutes but customizable using the `Access-Control-Max-Age` header). This means that if you make the same request again within the cache period, the browser won't send another preflight request. Instead, it will use the cached response to determine if the request is allowed. Mentoss does not currently support caching preflight responses, so each preflight request will result in a new preflight request to the server.
+
+Mentoss caches preflight responses in memory for the duration of the test run. This means that if you make the same preflighted request multiple times within a single test, Mentoss will only send the `OPTIONS` request once. However, you can manually clear the preflight cache by calling the `clearPreflightCache()` method. It's helpful to do this after each test
+
+```js {15-18}
+import { MockServer, FetchMocker } from "mentoss";
+
+const BASE_URL = "https://api.example.com";
+
+describe("My API", () => {
+	const server = new MockServer("https://www.example.com");
+	const mocker = new FetchMocker({
+		servers: [server],
+		baseUrl: BASE_URL,
+	});
+
+	// extract the fetch function
+	const myFetch = mocker.fetch;
+
+	// clear preflight cache entries
+	afterEach(() => {
+		mocker.clearPreflightCache();
+	});
+
+	it("should return a 200 status code", async () => {
+		// this is for the preflight request
+		server.options("/ping", {
+			status: 200,
+			headers: {
+				"Access-Control-Allow-Origin": BASE_URL,
+				"Access-Control-Allow-Headers": "Content-Type",
+			},
+		});
+
+		// this is the route that we want to call
+		server.get("/ping", {
+			status: 200,
+			headers: {
+				"Access-Control-Allow-Origin": BASE_URL,
+			},
+			body: { message: "pong" },
+		});
+
+		// make the request
+		const response = await myFetch("https://www.example.com/ping", {
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+
+		// check the response
+		expect(response.status).to.equal(200);
+	});
+});
+```
+
+<Aside type="tip">
+	The preflight cache is also cleared when you call `mocker.clearAll()`, so
+	you don't need to call `mocker.clearPreflightCache()` if you're already
+	calling `mocker.clearAll()`.
+</Aside>
+
+<Aside type="caution">
+While CORS support is mostly complete, credentialed requests (requests that include cookies or HTTP authentication information) are not yet supported. Mentoss throws an error if you try to use a credentialed request.
+</Aside>
+
+## Credentialed CORS Requests
+
+By default, credentials are not sent with CORS requests. If you want to include credentials with a CORS request, you must set the `credentials` option to `"include"` in the `fetch()` call. The server can then decide whether or not to accept the credentials by sending `Access-Control-Allow-Credentials: true` in the response. When that happens, the browser allows access to the response; otherwise, the browser blocks access to the response. This is true for both simple and preflighted requests.
+
+Mentoss can be used to mock credentialed CORS requests by setting the `credentials` option in the `FetchMocker` constructor and ensuring that the server responds with the appropriate `Access-Control-Allow-Credentials` header. Here's an example:
+
+```js {8,12,25}
+import { MockServer, FetchMocker } from "mentoss";
+	
+const BASE_URL = "https://www.example.com";
+const API_URL = "https://api.example.com";
+
+describe("My API", () => {
+	const server = new MockServer(API_URL);
+	const cookies = new CookieCredentials(API_URL);
+	const mocker = new FetchMocker({
+		servers: [server],
+		baseUrl: BASE_URL,
+		credentials: [cookies],
+	});
+
+	// extract the fetch function
+	const myFetch = mocker.fetch;
+
+	it("should return a 200 status code", async () => {
+		
+		// set up the route to test
+		server.get("/ping", {
+			status: 200,
+			headers: {
+				"Access-Control-Allow-Origin": BASE_URL,
+				"Access-Control-Allow-Credentials": "true",
+			},
+			body: { message: "pong" },
+		});
+
+		// make the request
+		const response = await myFetch("https://www.example.com/ping");
+
+		// check the response
+		expect(response.status).to.equal(200);
+	});
+});
+```
+
+In this example, the server responds with the `Access-Control-Allow-Credentials` header set to `"true"`. This allows the request to go through because the server allows credentials to be included with the request.
+
+### Preflighted Requests with Credentials
+
+When making a preflighted request with credentials, the server must respond with the appropriate `Access-Control-Allow-Credentials` header in both the preflight response and the actual response. Here's an example:
+
+```js {8,12,26,36}
+import { MockServer, FetchMocker } from "mentoss";
+
+const BASE_URL = "https://www.example.com";
+const API_URL = "https://api.example.com";
+
+describe("My API", () => {
+	const server = new MockServer(API_URL);
+	const cookies = new CookieCredentials(API_URL);
+	const mocker = new FetchMocker({
+		servers: [server],
+		baseUrl: BASE_URL,
+		credentials: [cookies],
+	});
+
+	// extract the fetch function
+	const myFetch = mocker.fetch;
+
+	it("should return a 200 status code", async () => {
+		
+		// this is for the preflight request
+		server.options("/ping", {
+			status: 200,
+			headers: {
+				"Access-Control-Allow-Origin": BASE_URL,
+				"Access-Control-Allow-Headers": "Custom",
+				"Access-Control-Allow-Credentials": "true",
+			},
+		});
+
+		// this is the route that we want to call
+		server.get("/ping", {
+			status: 200,
+			headers: {
+				"Access-Control-Allow-Origin": BASE_URL,
+				"Access-Control-Allow-Headers": "Custom",
+				"Access-Control-Allow-Credentials": "true",
+			},
+			body: { message: "pong" },
+		});
+
+		// make the request
+		const response = await myFetch("https://www.example.com/ping", {
+			headers: {
+				Custom: "header",
+			},
+		});
+
+		// check the response
+		expect(response.status).to.equal(200);
+	});
+});
+```
+
+In this example, the server responds to the preflight request with the appropriate `Access-Control-Allow-Credentials` header. This allows the original request to go through because the server allows credentials to be included with the request. The server also responds to the original request with the appropriate `Access-Control-Allow-Credentials` header, allowing the browser to access the response. If the server does not respond with the appropriate headers for either request, then the request will fail.

--- a/src/cookie-credentials.js
+++ b/src/cookie-credentials.js
@@ -1,0 +1,321 @@
+/**
+ * @fileoverview A class that represents cookie-based credentials.
+ * @author Nicholas C. Zakas
+ */
+
+/* global Headers */
+
+//-----------------------------------------------------------------------------
+// Imports
+//-----------------------------------------------------------------------------
+
+import { parseUrl } from "./util.js";
+
+//-----------------------------------------------------------------------------
+// Type Definitions
+//-----------------------------------------------------------------------------
+
+/** @typedef {import("./types.js").Credentials} Credentials */
+
+/**
+ * @typedef {Object} CookieInfo
+ * @property {string} name The name of the cookie.
+ * @property {string} value The value of the cookie.
+ * @property {string} [domain] The domain of the cookie.
+ * @property {string} [path] The path of the cookie.
+ * @property {boolean} [secure] The secure flag of the cookie.
+ * @property {boolean} [httpOnly] The HTTP-only flag of the cookie.
+ */
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+/**
+ * Asserts that a string is a valid domain that does not include a protocol or path.
+ * @param {string|undefined} domain The domain string to verify.
+ * @throws {Error} If the domain is not valid.
+ */
+function assertValidDomain(domain) {
+	if (!domain) {
+		throw new TypeError("Domain is required.");
+	}
+
+	const domainPattern = /^(?!:\/\/)([a-zA-Z0-9-_]+\.)+[a-zA-Z]{2,}$/;
+	if (!domainPattern.test(domain)) {
+		throw new TypeError(`Invalid domain: ${domain}`);
+	}
+}
+
+/**
+ * Represents a cookie.
+ * @implements {CookieInfo}
+ */
+class Cookie {
+	/**
+	 * The name of the cookie.
+	 * @type {string}
+	 */
+	name;
+
+	/**
+	 * The value of the cookie.
+	 * @type {string}
+	 */
+	value;
+
+	/**
+	 * The domain of the cookie.
+	 * @type {string}
+	 */
+	domain;
+
+	/**
+	 * The path of the cookie.
+	 * @type {string}
+	 */
+	path;
+
+	/**
+	 * The secure flag of the cookie.
+	 * @type {boolean}
+	 */
+	secure;
+
+	/**
+	 * The HTTP-only flag of the cookie.
+	 * @type {boolean}
+	 */
+	httpOnly;
+
+	/**
+	 * Creates a new CookieData instance.
+	 * @param {Object} options The options for the cookie.
+	 * @param {string} options.name The name of the cookie.
+	 * @param {string} options.value The value of the cookie.
+	 * @param {string|undefined} options.domain The domain of the cookie.
+	 * @param {string} [options.path=""] The path of the cookie.
+	 * @param {boolean} [options.secure=false] The secure flag of the cookie.
+	 * @param {boolean} [options.httpOnly=false] The HTTP-only flag of the cookie.
+	 */
+	constructor({
+		name,
+		value,
+		domain,
+		path = "/",
+		secure = false,
+		httpOnly = false,
+	}) {
+		assertValidDomain(domain);
+
+		if (!name) {
+			throw new TypeError("Cookie name is required.");
+		}
+
+		if (!value) {
+			throw new TypeError("Cookie value is required.");
+		}
+
+		this.name = name;
+		this.value = value;
+		this.domain = /** @type {string} */ (domain);
+		this.path = path;
+		this.secure = secure;
+		this.httpOnly = httpOnly;
+	}
+
+	/**
+	 * Gets a unique key for this cookie. This is used to store the cookie
+	 * in the credentials map to uniquely identify cookies based on their
+	 * properties.
+	 * @returns {string}
+	 */
+	get key() {
+		return JSON.stringify([this.name, this.domain, this.path, this.secure]);
+	}
+
+	/**
+	 * Checks if this cookie is a credential for the given request.
+	 * @param {Request} request The request to check.
+	 * @return {boolean} True if this cookie is a credential for the request.
+	 */
+	isCredentialForRequest(request) {
+		const url = parseUrl(request.url);
+
+		return (
+			url.hostname.endsWith(this.domain) &&
+			url.pathname.startsWith(this.path) &&
+			(this.secure ? url.protocol === "https:" : true)
+		);
+	}
+
+	/**
+	 * Converts this cookie to a cookie header string.
+	 * @return {string} The cookie header string.
+	 */
+	toCookieHeaderString() {
+		return `${encodeURIComponent(this.name)}=${encodeURIComponent(this.value)}`;
+	}
+
+	/**
+	 * Returns a string representation of the cookie.
+	 * @return {string} The string representation of the cookie.
+	 */
+	toString() {
+		let cookieString = `🍪 [Cookie: ${this.name}=${this.value}`;
+
+		if (this.domain) {
+			cookieString += `; Domain=${this.domain}`;
+		}
+
+		if (this.path) {
+			cookieString += `; Path=${this.path}`;
+		}
+
+		if (this.secure) {
+			cookieString += `; Secure`;
+		}
+
+		if (this.httpOnly) {
+			cookieString += `; HttpOnly`;
+		}
+
+		return cookieString + "]";
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
+
+/**
+ * A class that represents cookie-based credentials.
+ * @implements {Credentials}
+ */
+export class CookieCredentials {
+	/**
+	 * The domain for the cookie credentials.
+	 * @type {string|undefined}
+	 */
+	#domain;
+
+	/**
+	 * The cookies for the cookie credentials.
+	 * @type {Map<string,Cookie>}
+	 */
+	#cookies = new Map();
+
+	/**
+	 * The base URL for the cookie credentials. This will be overwritten
+	 * by the fetch mocker when in use.
+	 * @type {string}
+	 */
+	#basePath = "/";
+
+	/**
+	 * Creates a new CookieCredentials instance.
+	 * @param {string|URL} [baseUrl] The base URL for the credentials
+	 */
+	constructor(baseUrl) {
+		if (baseUrl) {
+			const url = parseUrl(baseUrl);
+			this.#domain = url.hostname;
+			this.#basePath = url.pathname;
+		}
+	}
+
+	/**
+	 * Gets the domain for the cookie credentials.
+	 * @returns {string|undefined} The domain for the cookie credentials.
+	 */
+	get domain() {
+		return this.#domain;
+	}
+
+	/**
+	 * Gets the base path for the cookie credentials.
+	 * @return {string} The base path for the cookie credentials.
+	 */
+	get basePath() {
+		return this.#basePath;
+	}
+
+	/**
+	 * Sets a cookie for the cookie credentials.
+	 * @param {CookieInfo} cookieInfo The cookie to set.
+	 * @returns {void}
+	 * @throws {TypeError} If the cookie already exists.
+	 * @throws {TypeError} If the cookie domain does not match the credentials domain.
+	 */
+	setCookie(cookieInfo) {
+		const cookie = new Cookie({
+			domain: this.#domain,
+			path: this.#basePath,
+			...cookieInfo,
+		});
+		const cookieKey = cookie.key;
+
+		if (this.#cookies.has(cookieKey)) {
+			throw new TypeError(`Cookie already exists: ${cookie.toString()}`);
+		}
+
+		if (this.#domain && !cookie.domain.endsWith(this.#domain)) {
+			throw new TypeError(
+				`Cookie domain must end with ${this.#domain}: ${cookie.toString()}`,
+			);
+		}
+
+		this.#cookies.set(cookie.key, cookie);
+	}
+
+	/**
+	 * Deletes a cookie from the cookie credentials.
+	 * @param {CookieInfo} cookieInfo The cookie to delete.
+	 * @returns {void}
+	 * @throws {TypeError} If the cookie does not exist.
+	 */
+	deleteCookie(cookieInfo) {
+		const cookie = new Cookie({
+			domain: this.#domain,
+			path: this.#basePath,
+			...cookieInfo,
+		});
+		const cookieKey = cookie.key;
+
+		if (!this.#cookies.has(cookieKey)) {
+			throw new TypeError(`Cookie does not exist: ${cookie.toString()}`);
+		}
+
+		this.#cookies.delete(cookieKey);
+	}
+
+	/**
+	 * Gets the credentials headers for the given request.
+	 * @param {Request} request The request to get the credentials for.
+	 * @return {Headers} The credentials headers for the request.
+	 */
+	getHeadersForRequest(request) {
+		const headers = new Headers();
+		const cookies = [];
+
+		for (const cookie of this.#cookies.values()) {
+			if (cookie.isCredentialForRequest(request)) {
+				cookies.push(cookie.toCookieHeaderString());
+			}
+		}
+
+		if (cookies.length > 0) {
+			headers.append("Cookie", cookies.join("; "));
+		}
+
+		return headers;
+	}
+
+	/**
+	 * Clears all cookies from the cookie credentials.
+	 * @returns {void}
+	 */
+	clear() {
+		this.#cookies.clear();
+	}
+}

--- a/src/index.js
+++ b/src/index.js
@@ -6,3 +6,4 @@
 
 export { MockServer } from "./mock-server.js";
 export { FetchMocker } from "./fetch-mocker.js";
+export { CookieCredentials } from "./cookie-credentials.js";

--- a/src/mock-server.js
+++ b/src/mock-server.js
@@ -293,7 +293,6 @@ export class MockServer {
 		this.baseUrl = baseUrl;
 	}
 
-	
 	/**
 	 * Returns the routes that have not been matched.
 	 * @returns {Array<Route>} The unmatched routes.
@@ -301,7 +300,7 @@ export class MockServer {
 	get #unmatchedRoutes() {
 		return this.#routes.filter(route => !this.#matched.has(route));
 	}
-	
+
 	/**
 	 * Returns the routes that have been matched.
 	 * @returns {Array<Route>} The matched routes.
@@ -309,7 +308,7 @@ export class MockServer {
 	get #matchedRoutes() {
 		return this.#routes.filter(route => this.#matched.has(route));
 	}
-	
+
 	// #region: Adding Routes
 
 	/**
@@ -427,7 +426,7 @@ export class MockServer {
 		assertNoMethod(request);
 		this.#addRoute("OPTIONS", request, response);
 	}
-	
+
 	// #endregion: Adding Routes
 
 	/**
@@ -494,7 +493,7 @@ export class MockServer {
 	}
 
 	// #region Testing Helpers
-	
+
 	/**
 	 * Determines if a route has been called.
 	 * @param {RequestPattern|string} request The request pattern to check.
@@ -553,6 +552,6 @@ export class MockServer {
 			);
 		}
 	}
-	
+
 	// #endregion: Testing Helpers
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,3 +37,15 @@ export interface ResponsePattern {
 	 */
 	delay?: number;
 }
+
+export interface Credentials {
+	/**
+	 * Returne the credential headers for a given request.
+	 */
+	getHeadersForRequest(request: Request): Headers;
+
+	/**
+	 * Clear all credentials.
+	 */
+	clear(): void;
+}

--- a/src/util.js
+++ b/src/util.js
@@ -56,6 +56,40 @@ function formatBody(body) {
 //-----------------------------------------------------------------------------
 
 /**
+ * Represents an error that occurs when a URL is invalid.
+ * @extends {Error}
+ */
+export class URLParseError extends Error {
+	/**
+	 * Creates a new URLParseError instance.
+	 * @param {string} url The URL that caused the error.
+	 */
+	constructor(url) {
+		super(`Invalid URL: ${url}`);
+		this.name = "URLParseError";
+	}
+}
+
+/**
+ * Parses a URL and returns a URL object. This is used instead
+ * of the URL constructor to provide a standard error message,
+ * because different runtimes use different messages.
+ * @param {string|URL} url The URL to parse.
+ * @returns {URL} The parsed URL.
+ */
+export function parseUrl(url) {
+	if (url instanceof URL) {
+		return url;
+	}
+
+	try {
+		return new URL(url);
+	} catch {
+		throw new URLParseError(url);
+	}
+}
+
+/**
  * Reads the body from a request based on the HTTP headers.
  * @param {Request} request The request to read the body from.
  * @returns {Promise<string|any|FormData|null>} The body of the request.

--- a/tests/cookie-credentials.test.js
+++ b/tests/cookie-credentials.test.js
@@ -218,16 +218,15 @@ describe("CookieCredentials", () => {
 					});
 				}, /name is required/gi);
 			});
-
-			it("should throw an error when value is missing", () => {
+			
+			it("should throw an error when domain is missing", () => {
 				const credentials = new CookieCredentials();
 
 				assert.throws(() => {
 					credentials.deleteCookie({
 						name: "session",
-						domain: BASE_DOMAIN,
 					});
-				}, /value is required/gi);
+				}, /Domain is required/gi);
 			});
 		});
 	});
@@ -383,6 +382,7 @@ describe("CookieCredentials", () => {
 				);
 				assert.strictEqual(headers.get("Cookie"), null);
 			});
+			
 		});
 	});
 });

--- a/tests/cookie-credentials.test.js
+++ b/tests/cookie-credentials.test.js
@@ -1,0 +1,388 @@
+/**
+ * @fileoverview Tests for the CookieCredentials class.
+ * @author Nicholas C. Zakas
+ */
+
+/* global Request */
+
+//-----------------------------------------------------------------------------
+// Imports
+//-----------------------------------------------------------------------------
+
+import assert from "node:assert";
+import { CookieCredentials } from "../src/cookie-credentials.js";
+
+//-----------------------------------------------------------------------------
+// Data
+//-----------------------------------------------------------------------------
+
+const BASE_DOMAIN = "example.com";
+const BASE_URL = `https://${BASE_DOMAIN}`;
+const SUB_DOMAIN = "sub.example.com";
+const SUB_URL = `https://${SUB_DOMAIN}`;
+
+//-----------------------------------------------------------------------------
+// Tests
+//-----------------------------------------------------------------------------
+
+describe("CookieCredentials", () => {
+	describe("constructor", () => {
+		it("should create instance with undefined domain and / basePath when called with no argument", () => {
+			const credentials = new CookieCredentials();
+			assert.strictEqual(credentials.domain, undefined);
+			assert.strictEqual(credentials.basePath, "/");
+		});
+
+		it("should create instance with valid domain and / basePath when called with a string", () => {
+			const credentials = new CookieCredentials(BASE_URL);
+			assert.strictEqual(credentials.domain, BASE_DOMAIN);
+			assert.strictEqual(credentials.basePath, "/");
+		});
+
+		it("should create instance with valid domain and basePath when called with a string and basePath", () => {
+			const credentials = new CookieCredentials(BASE_URL + "/admin");
+			assert.strictEqual(credentials.domain, BASE_DOMAIN);
+			assert.strictEqual(credentials.basePath, "/admin");
+		});
+
+		it("should throw an error when called with an invalid URL", () => {
+			assert.throws(() => {
+				new CookieCredentials("invalid-url");
+			}, /Invalid URL/gi);
+		});
+	});
+
+	describe("setCookie()", () => {
+		describe("Base URL set", () => {
+			it("should set a cookie successfully", () => {
+				const credentials = new CookieCredentials(BASE_URL);
+				credentials.setCookie({
+					name: "session",
+					value: "123",
+				});
+				assert.strictEqual(credentials.domain, BASE_DOMAIN);
+			});
+
+			it("should throw an error when setting a duplicate cookie", () => {
+				const credentials = new CookieCredentials(BASE_URL);
+				credentials.setCookie({
+					name: "session",
+					value: "123",
+				});
+
+				assert.throws(() => {
+					credentials.setCookie({
+						name: "session",
+						value: "456",
+					});
+				}, /Cookie already exists/gi);
+			});
+
+			it("should throw an error when setting a cookie with a different domain", () => {
+				const credentials = new CookieCredentials(SUB_URL);
+
+				assert.throws(() => {
+					credentials.setCookie({
+						name: "session",
+						value: "123",
+						domain: BASE_DOMAIN,
+					});
+				}, /Cookie domain must end with sub\.example\.com/gi);
+			});
+		});
+
+		describe("No base URL set", () => {
+			it("should set a cookie successfully", () => {
+				const credentials = new CookieCredentials();
+				credentials.setCookie({
+					name: "session",
+					value: "123",
+					domain: BASE_DOMAIN,
+				});
+			});
+
+			it("should throw an error when setting a duplicate cookie", () => {
+				const credentials = new CookieCredentials();
+				credentials.setCookie({
+					name: "session",
+					value: "123",
+					domain: BASE_DOMAIN,
+				});
+
+				assert.throws(() => {
+					credentials.setCookie({
+						name: "session",
+						value: "456",
+						domain: BASE_DOMAIN,
+					});
+				}, /Cookie already exists/gi);
+			});
+
+			it("should throw an error when setting a cookie without a domain", () => {
+				const credentials = new CookieCredentials();
+
+				assert.throws(() => {
+					credentials.setCookie({
+						name: "session",
+						value: "123",
+					});
+				}, /domain is required/gi);
+			});
+
+			it("should throw an error when name is missing", () => {
+				const credentials = new CookieCredentials();
+
+				assert.throws(() => {
+					credentials.setCookie({
+						value: "123",
+						domain: BASE_DOMAIN,
+					});
+				}, /name is required/gi);
+			});
+
+			it("should throw an error when value is missing", () => {
+				const credentials = new CookieCredentials();
+
+				assert.throws(() => {
+					credentials.setCookie({
+						name: "session",
+						domain: BASE_DOMAIN,
+					});
+				}, /value is required/gi);
+			});
+		});
+	});
+
+	describe("deleteCookie()", () => {
+		describe("Base URL set", () => {
+			it("should delete an existing cookie", () => {
+				const credentials = new CookieCredentials(BASE_URL);
+				credentials.setCookie({
+					name: "session",
+					value: "123",
+				});
+
+				credentials.deleteCookie({
+					name: "session",
+					value: "123",
+				});
+			});
+
+			it("should throw an error when deleting a non-existent cookie", () => {
+				const credentials = new CookieCredentials(BASE_URL);
+
+				assert.throws(() => {
+					credentials.deleteCookie({
+						name: "session",
+						value: "123",
+					});
+				}, /Cookie does not exist/gi);
+			});
+		});
+
+		describe("No base URL set", () => {
+			it("should delete an existing cookie", () => {
+				const credentials = new CookieCredentials();
+				credentials.setCookie({
+					name: "session",
+					value: "123",
+					domain: BASE_DOMAIN,
+				});
+
+				credentials.deleteCookie({
+					name: "session",
+					value: "123",
+					domain: BASE_DOMAIN,
+				});
+			});
+
+			it("should throw an error when deleting a non-existent cookie", () => {
+				const credentials = new CookieCredentials();
+
+				assert.throws(() => {
+					credentials.deleteCookie({
+						name: "session",
+						value: "123",
+						domain: BASE_DOMAIN,
+					});
+				}, /Cookie does not exist/gi);
+			});
+
+			it("should throw an error when name is missing", () => {
+				const credentials = new CookieCredentials();
+
+				assert.throws(() => {
+					credentials.deleteCookie({
+						value: "123",
+						domain: BASE_DOMAIN,
+					});
+				}, /name is required/gi);
+			});
+
+			it("should throw an error when value is missing", () => {
+				const credentials = new CookieCredentials();
+
+				assert.throws(() => {
+					credentials.deleteCookie({
+						name: "session",
+						domain: BASE_DOMAIN,
+					});
+				}, /value is required/gi);
+			});
+		});
+	});
+
+	describe("getHeadersForRequest()", () => {
+		describe("Base URL set", () => {
+			it("should return headers with matching cookies", () => {
+				const credentials = new CookieCredentials(BASE_URL);
+				credentials.setCookie({
+					name: "session",
+					value: "123",
+				});
+
+				const headers = credentials.getHeadersForRequest(
+					new Request(BASE_URL),
+				);
+				assert.strictEqual(headers.get("Cookie"), "session=123");
+			});
+
+			it("should not return headers with non-matching cookies", () => {
+				const credentials = new CookieCredentials(SUB_URL);
+				credentials.setCookie({
+					name: "session",
+					value: "123",
+				});
+
+				const headers = credentials.getHeadersForRequest(
+					new Request(BASE_URL),
+				);
+				assert.strictEqual(headers.get("Cookie"), null);
+			});
+
+			it("should return headers with matching cookies for subdirectory", () => {
+				const credentials = new CookieCredentials(BASE_URL);
+				credentials.setCookie({
+					name: "session",
+					value: "123",
+				});
+
+				const headers = credentials.getHeadersForRequest(
+					new Request(BASE_URL + "/admin"),
+				);
+				assert.strictEqual(headers.get("Cookie"), "session=123");
+			});
+
+			it("should not return headers with non-matching cookies for subdirectory", () => {
+				const credentials = new CookieCredentials(BASE_URL);
+				credentials.setCookie({
+					name: "session",
+					value: "123",
+					path: "/admin",
+				});
+
+				const headers = credentials.getHeadersForRequest(
+					new Request(BASE_URL),
+				);
+
+				assert.strictEqual(headers.get("Cookie"), null);
+			});
+
+			it("should not return headers when the cookie is deleted", () => {
+				const credentials = new CookieCredentials(BASE_URL);
+				credentials.setCookie({
+					name: "session",
+					value: "123",
+				});
+				credentials.deleteCookie({
+					name: "session",
+					value: "123",
+				});
+
+				const headers = credentials.getHeadersForRequest(
+					new Request(BASE_URL),
+				);
+				assert.strictEqual(headers.get("Cookie"), null);
+			});
+		});
+
+		describe("No base URL set", () => {
+			it("should return headers with matching cookies", () => {
+				const credentials = new CookieCredentials();
+				credentials.setCookie({
+					name: "session",
+					value: "123",
+					domain: BASE_DOMAIN,
+				});
+
+				const headers = credentials.getHeadersForRequest(
+					new Request(BASE_URL),
+				);
+				assert.strictEqual(headers.get("Cookie"), "session=123");
+			});
+
+			it("should not return headers with non-matching cookies", () => {
+				const credentials = new CookieCredentials();
+				credentials.setCookie({
+					name: "session",
+					value: "123",
+					domain: SUB_DOMAIN,
+				});
+
+				const headers = credentials.getHeadersForRequest(
+					new Request(BASE_URL),
+				);
+				assert.strictEqual(headers.get("Cookie"), null);
+			});
+
+			it("should not return headers with path that doesn't match request", () => {
+				const credentials = new CookieCredentials();
+				credentials.setCookie({
+					name: "session",
+					value: "123",
+					domain: BASE_DOMAIN,
+					path: "/admin",
+				});
+
+				const headers = credentials.getHeadersForRequest(
+					new Request(BASE_URL),
+				);
+				assert.strictEqual(headers.get("Cookie"), null);
+			});
+
+			it("should not return headers when the cookie is deleted", () => {
+				const credentials = new CookieCredentials();
+				credentials.setCookie({
+					name: "session",
+					value: "123",
+					domain: BASE_DOMAIN,
+				});
+				credentials.deleteCookie({
+					name: "session",
+					value: "123",
+					domain: BASE_DOMAIN,
+				});
+
+				const headers = credentials.getHeadersForRequest(
+					new Request(BASE_URL),
+				);
+				assert.strictEqual(headers.get("Cookie"), null);
+			});
+
+			it("should not return headers when clear() is called", () => {
+				const credentials = new CookieCredentials();
+				credentials.setCookie({
+					name: "session",
+					value: "123",
+					domain: BASE_DOMAIN,
+				});
+				credentials.clear();
+
+				const headers = credentials.getHeadersForRequest(
+					new Request(BASE_URL),
+				);
+				assert.strictEqual(headers.get("Cookie"), null);
+			});
+		});
+	});
+});

--- a/tests/mock-server.test.js
+++ b/tests/mock-server.test.js
@@ -1020,9 +1020,8 @@ describe("MockServer", () => {
 			server.assertAllRoutesCalled();
 		});
 	});
-	
+
 	describe("uncalledRoutes", () => {
-		
 		it("should return all uncalled routes when one is called", async () => {
 			server.get("/test", { status: 200, body: "OK" });
 			server.get("/test2", { status: 200, body: "OK" });
@@ -1039,7 +1038,7 @@ describe("MockServer", () => {
 				"🚧 [Route: POST https://example.com/test2 -> 200]",
 			]);
 		});
-		
+
 		it("should return no uncalled routes when all are called", async () => {
 			server.get("/test", { status: 200, body: "OK" });
 			server.get("/test2", { status: 200, body: "OK" });
@@ -1066,7 +1065,6 @@ describe("MockServer", () => {
 
 			assert.deepStrictEqual(server.uncalledRoutes, []);
 		});
-		
 	});
 
 	describe("Input validation", () => {


### PR DESCRIPTION
This pull request includes updates to the documentation for mocking browser requests using Mentoss, focusing on handling credentialed requests and CORS (Cross-Origin Resource Sharing) requests. The most important changes include restructuring the documentation, adding new sections, and providing detailed examples.
