### PR TITLE
refactor: Custom request class

### DIFF
--- a/src/custom-request.js
+++ b/src/custom-request.js
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview A custom request class that allows for more control over requests.
+ * @author Nicholas C. Zakas
+ */
+
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
+
+/**
+ * Creates a custom request class that extends a given Request class.
+ * @param {typeof Request} RequestClass The class to extend.
+ * @returns {typeof Request} The custom request class.
+ */
+export function createCustomRequest(RequestClass) {
+    
+    return class CustomRequest extends RequestClass {
+
+        /**
+         * The ID of the request.
+         * @type {string}
+         */
+        id = Math.random().toString(36).slice(2);
+        
+        /**
+         * Creates a new instance.
+         * @param {string|Request|URL} input The URL or Request object to fetch.
+         * @param {RequestInit} [init] The options for the fetch.
+         */
+        constructor(input, init) {
+            super(input, init);
+            
+            // ensure id is not writable
+            Object.defineProperty(this, "id", { writable: false });
+            
+            /*
+             * Not all runtimes properly support the `credentials` property.
+			 * Bun's fetch implementation sets credentials to "include" by default
+			 * and doesn't allow overwriting that value when creating a Request.
+			 * We therefore need to hack it together to make sure this works in
+			 * Bun correctly.
+			 * https://github.com/oven-sh/bun/issues/17052
+             * 
+             * Deno doesn't support the `credentials` property on Request and
+             * it's undefined so we need to fix that as well.
+			 */
+            const expectedCredentials = init?.credentials ?? "same-origin";
+            
+			if (expectedCredentials !== this.credentials) {
+				Object.defineProperty(this, "credentials", {
+					configurable: true,
+					enumerable: true,
+					value: expectedCredentials,
+					writable: false,
+				});
+			}
+        }
+        
+        /**
+         * Clones the request. Clones shared the same ID.
+         * @returns {CustomRequest} A new instance of the request.
+         */
+        clone() {
+            const clonedRequest = new CustomRequest(this);
+            Object.defineProperty(clonedRequest, "id", { value: this.id });
+            return clonedRequest;
+        }
+    };
+}

--- a/src/fetch-mocker.js
+++ b/src/fetch-mocker.js
@@ -18,6 +18,7 @@ import {
 	CORS_ORIGIN,
 	CorsError,
 } from "./cors.js";
+import { createCustomRequest } from "./custom-request.js";
 
 //-----------------------------------------------------------------------------
 // Type Definitions
@@ -178,7 +179,7 @@ export class FetchMocker {
 		this.#credentials = credentials;
 		this.#baseUrl = createBaseUrl(baseUrl);
 		this.#Response = CustomResponse;
-		this.#Request = CustomRequest;
+		this.#Request = createCustomRequest(CustomRequest);
 
 		// must be least one server
 		if (!servers || servers.length === 0) {
@@ -213,22 +214,6 @@ export class FetchMocker {
 			let useCors = false;
 			let useCorsCredentials = false;
 			let preflightData;
-
-			/*
-			 * Bun's fetch implementation sets credentials to "include" by default
-			 * and doesn't allow overwriting that value when creating a Request.
-			 * We therefore need to hack it together to make sure this works in
-			 * Bun correctly.
-			 * https://github.com/oven-sh/bun/issues/17052
-			 */
-			if ("Bun" in globalThis) {
-				Object.defineProperty(request, "credentials", {
-					configurable: true,
-					enumerable: true,
-					value: init?.credentials ?? "same-origin",
-					writable: false,
-				});
-			}
 
 			// if there's a base URL then we need to check for CORS
 			if (this.#baseUrl) {

--- a/tests/custom-request.test.js
+++ b/tests/custom-request.test.js
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview Tests for the custom request class.
+ * @author Nicholas C. Zakas
+ */
+
+/* global Request */
+
+//-----------------------------------------------------------------------------
+// Imports
+//-----------------------------------------------------------------------------
+
+import assert from "node:assert";
+import { createCustomRequest } from "../src/custom-request.js";
+
+//-----------------------------------------------------------------------------
+// Tests
+//-----------------------------------------------------------------------------
+
+describe("createCustomRequest()", () => {
+
+    let CustomRequest;
+    const TEST_URL = "https://example.com/";
+    
+    beforeEach(() => {
+        CustomRequest = createCustomRequest(Request);
+    });
+
+    it("should create requests with unique IDs", () => {
+        const request1 = new CustomRequest(TEST_URL);
+        const request2 = new CustomRequest(TEST_URL);
+        
+        assert.ok(typeof request1.id === "string");
+        assert.ok(request1.id.length > 0);
+        assert.notStrictEqual(request1.id, request2.id);
+    });
+
+    it("should not allow ID to be modified", () => {
+        const request = new CustomRequest(TEST_URL);
+        const originalId = request.id;
+        
+        assert.throws(() => {
+            request.id = "new-id";
+        }, TypeError);
+        
+        assert.strictEqual(request.id, originalId);
+    });
+
+    it("should preserve ID when cloning", () => {
+        const request = new CustomRequest(TEST_URL);
+        const clonedRequest = request.clone();
+        
+        assert.strictEqual(clonedRequest.id, request.id);
+    });
+
+    it("should maintain standard Request functionality", () => {
+        const request = new CustomRequest(TEST_URL);
+        
+        assert.strictEqual(request.url, TEST_URL);
+        assert.ok(request instanceof Request);
+    });
+});


### PR DESCRIPTION
This pull request introduces a new custom request class to enhance control over requests and includes corresponding updates to the `FetchMocker` class and test coverage. This allows me to both add info to requests (such as `id` to track requests through cloned `Request` objects) and to address runtime-specific bugs such as Bun and Deno's lack of supporting the `credentials` property.

### Introduction of Custom Request Class:

* [`src/custom-request.js`](diffhunk://#diff-3d024b2982939484b878c8446a661b479428d7e4bc40a72140164c7ef7ce0cb9R1-R70): Added a new `createCustomRequest` function that generates a custom request class extending the standard `Request` class. This custom class includes unique IDs for each request, ensures the ID is immutable, and handles credentials compatibility across different runtimes.

### Updates to FetchMocker:

* [`src/fetch-mocker.js`](diffhunk://#diff-09d3018654f9d696c2ce0a5938eb9b5dd6adb822704efafcbfde8b6342f246c5L181-R182): Modified the `FetchMocker` class to use the new `createCustomRequest` function instead of directly using `CustomRequest`. This change ensures that the new custom request class is utilized.
* [`src/fetch-mocker.js`](diffhunk://#diff-09d3018654f9d696c2ce0a5938eb9b5dd6adb822704efafcbfde8b6342f246c5L217-L232): Removed redundant code related to handling credentials in Bun, as this logic is now encapsulated within the custom request class.

### Testing:

* [`tests/custom-request.test.js`](diffhunk://#diff-b0ef3f77e45936f710228582cdbabb4884d7c75bef5e28d89ca434811ef037a6R1-R61): Added new tests to verify the functionality of the custom request class, including tests for unique IDs, immutability of IDs, cloning behavior, and maintaining standard `Request` functionality.

### Import Adjustments:

* [`src/fetch-mocker.js`](diffhunk://#diff-09d3018654f9d696c2ce0a5938eb9b5dd6adb822704efafcbfde8b6342f246c5R21): Added an import statement for the `createCustomRequest` function.