### PR TITLE
fix: Request without a body should not throw an error

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -94,18 +94,27 @@ export function parseUrl(url) {
  * @param {Request} request The request to read the body from.
  * @returns {Promise<string|any|FormData|null>} The body of the request.
  */
-export function getBody(request) {
+export async function getBody(request) {
+	
 	// first get the content type
 	const contentType = request.headers.get("content-type");
 
 	// if there's no content type, there's no body
 	if (!contentType) {
 		return Promise.resolve(null);
+	}	
+	
+	// next try to read the body as text to see if there's a body
+	const text = await request.clone().text();
+	
+	// if there's no body, return null
+	if (!text) {
+		return Promise.resolve(null);
 	}
 
 	// if it's a text format then return a string
 	if (contentType.startsWith("text")) {
-		return request.text();
+		return text;
 	}
 
 	// if the content type is JSON, parse the body as JSON

--- a/tests/mock-server.test.js
+++ b/tests/mock-server.test.js
@@ -563,6 +563,29 @@ describe("MockServer", () => {
 				"application/json",
 			);
 		});
+		
+		it("should return response when JSON request is sent without a body", async () => {
+			server.post("/test", {
+				status: 200,
+				body: { foo: "bar" },
+			});
+
+			const request = createRequest({
+				method: "POST",
+				url: `${BASE_URL}/test`,
+				headers: {
+					"content-type": "application/json",
+				},
+			});
+
+			const { response } = await server.traceReceive(request);
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(response.statusText, "OK");
+			assert.strictEqual(
+				response.headers.get("content-type"),
+				"application/json",
+			);
+		});
 	});
 
 	describe("Query Strings", () => {


### PR DESCRIPTION
This pull request includes changes to enhance the handling of request bodies in the `getBody` function and adds a new test case to ensure proper functionality when a JSON request is sent without a body.

fixes #48

### Enhancements to request body handling:

* [`src/util.js`](diffhunk://#diff-9c0ec1b0a889e599f3ff81590864dd9dc65684a86b41f1da75acc53fafed12e3L97-R98): Modified the `getBody` function to be asynchronous and improved handling of cases where the request body is empty. [[1]](diffhunk://#diff-9c0ec1b0a889e599f3ff81590864dd9dc65684a86b41f1da75acc53fafed12e3L97-R98) [[2]](diffhunk://#diff-9c0ec1b0a889e599f3ff81590864dd9dc65684a86b41f1da75acc53fafed12e3R107-R117)

### Testing improvements:

* [`tests/mock-server.test.js`](diffhunk://#diff-8ea18cf1c7d7bb1ad2967a064ede011cc0f2b983f81dc73877857d6b379049dfR566-R588): Added a new test case to verify that the server correctly handles a JSON request without a body and returns the appropriate response.