### PR TITLE
fix: Limit Access-Control-Request-Headers to unsafe headers only

### DIFF
--- a/src/cors.js
+++ b/src/cors.js
@@ -392,6 +392,44 @@ export function validateCorsRequest(request, origin) {
 }
 
 /**
+ * Gets an array of headers that are not allowed in a CORS simple request.
+ * @param {Request} request The request to check.
+ * @returns {string[]} Array of header names that are not simple headers.
+ */
+export function getNonSimpleHeaders(request) {
+    const result = [];
+    const headers = request.headers;
+
+    for (const header of headers.keys()) {
+        
+        // Range header needs special validation
+        if (header === "range") {
+            const rangeValue = headers.get(header);
+            if (rangeValue && !isSimpleRangeHeader(rangeValue)) {
+                result.push(header);
+            }
+            continue;
+        }
+
+        // Content-Type header needs special validation
+        if (header === "content-type") {
+            const contentType = headers.get(header);
+            if (contentType && !simpleRequestContentTypes.has(contentType)) {
+                result.push(header);
+            }
+            continue;
+        }
+
+        // Check if header is in the safe list
+        if (!safeRequestHeaders.has(header)) {
+            result.push(header);
+        }
+    }
+
+    return result;
+}
+
+/**
  * A class for storing CORS preflight data.
  */
 export class CorsPreflightData {


### PR DESCRIPTION
This pull request introduces a new function to handle non-simple headers in CORS requests and updates the `FetchMocker` class to use this function. Additionally, it includes comprehensive tests for the new functionality.

### Enhancements to CORS Handling:

* [`src/cors.js`](diffhunk://#diff-e7461d918b27ad31cebeb3be2f2e87fe5b8fea3d353077eefbb6d82a7644f4f4R394-R431): Added the `getNonSimpleHeaders` function to identify headers that are not allowed in a CORS simple request. This function checks for special cases like the `Range` and `Content-Type` headers and ensures they are validated correctly.
* [`src/fetch-mocker.js`](diffhunk://#diff-09d3018654f9d696c2ce0a5938eb9b5dd6adb822704efafcbfde8b6342f246c5L360-R380): Updated the `FetchMocker` class to use the `getNonSimpleHeaders` function when creating a preflight request. This ensures that only non-simple headers are included in the `Access-Control-Request-Headers` header.

### Tests:

* [`tests/cors.test.js`](diffhunk://#diff-e2218e137dd57fe9f6b7d5b349184d775f869b9046e4c40646fe6555ded4969cR178-R253): Added a new test suite for the `getNonSimpleHeaders` function to verify its behavior with various headers, including simple headers, non-simple headers, and special cases like `Range` and `Content-Type`.
* [`tests/fetch-mocker.test.js`](diffhunk://#diff-c7749aa975a360a952d495ce66db5a38c09de5fa882d6cf00f2a86949208c1b9R1058-R1174): Enhanced the `FetchMocker` tests to include scenarios for `Access-Control-Allow-Headers` and `Access-Control-Request-Headers`, ensuring the correct handling of non-simple headers in preflight requests.

### Documentation:

* [`src/fetch-mocker.js`](diffhunk://#diff-09d3018654f9d696c2ce0a5938eb9b5dd6adb822704efafcbfde8b6342f246c5R353): Added a reference to the CORS preflight fetch specification in the `FetchMocker` class to provide context for the changes.