### PR TITLE
fix: Ensure Response#type is set correctly for CORS requests

### DIFF
--- a/tests/custom-request.test.js
+++ b/tests/custom-request.test.js
@@ -52,6 +52,22 @@ describe("createCustomRequest()", () => {
         assert.ok(request instanceof Request);
     });
     
+    describe("mode", () => {
+        
+        it("should allow mode to be set to 'no-cors'", () => {
+            const request = new CustomRequest(TEST_URL, { mode: "no-cors" });
+            
+            assert.strictEqual(request.mode, "no-cors");
+        });
+        
+        it("should have a default mode of 'cors'", () => {
+            const request = new CustomRequest(TEST_URL);
+            
+            assert.strictEqual(request.mode, "cors");
+        });
+    });
+    
+    
     describe("clone()", () => {
 
         it("should have the same class as the original request", () => {

--- a/tests/mock-server.test.js
+++ b/tests/mock-server.test.js
@@ -28,10 +28,11 @@ const BASE_URL = "https://example.com";
  * @param {Object} options Request options
  * @returns {Request} A new request object
  */
-function createRequest({ method, url, headers = {}, body = undefined }) {
+function createRequest({ method, url, headers = {}, body = undefined, mode = "cors" }) {
 	const requestInit = {
 		method,
 		headers,
+		mode
 	};
 
 	if (body !== undefined) {
@@ -586,6 +587,48 @@ describe("MockServer", () => {
 				"application/json",
 			);
 		});
+		
+		describe("Responses", () => {
+			
+			it("should return a response with type of 'cors' when a CORS request is received", async () => {
+				server.get("/test", { status: 200, body: "OK" });
+	
+				const request = createRequest({
+					method: "GET",
+					url: `${BASE_URL}/test`,
+					mode: "cors",
+				});
+	
+				const { response } = await server.traceReceive(request);
+				assert.strictEqual(response.type, "cors");
+			});
+			
+			it("should return a response with type of 'cors' by default (requests are CORS by default)", async () => {
+				server.get("/test", { status: 200, body: "OK" });
+	
+				const request = createRequest({
+					method: "GET",
+					url: `${BASE_URL}/test`,
+				});
+	
+				const { response } = await server.traceReceive(request);
+				assert.strictEqual(response.type, "cors");
+			});
+			
+			it("should return a response with a type of 'same-origin' when a non-CORS request is received", async () => {
+				server.get("/test", { status: 200, body: "OK" });
+	
+				const request = createRequest({
+					method: "GET",
+					url: `${BASE_URL}/test`,
+					mode: "same-origin"
+				});
+				
+				const { response } = await server.traceReceive(request);
+				assert.strictEqual(response.type, "default");
+			});
+		});
+		
 	});
 
 	describe("Query Strings", () => {


### PR DESCRIPTION
This pull request ensures that `Response#type` is set to `"cors"` when `Request#mode` is set to `"cors"` (which is the default). Further PRs will focus on correctly setting `Response#type` for other values of `Request#mode`.

The most important changes include updating the `Route` class to handle response properties more effectively, adding tests for request modes, and modifying the `MockServer` class to ensure proper response types.

Improvements to `Route` class:

* Updated the `createResponse` method to handle different response patterns and ensure response properties are correctly assigned. [[1]](diffhunk://#diff-5024b7448f56bf978cf6ef5e933780ebabaf2d2977e6650c3c4df42c484245c4L213-R214) [[2]](diffhunk://#diff-5024b7448f56bf978cf6ef5e933780ebabaf2d2977e6650c3c4df42c484245c4R229-R252) [[3]](diffhunk://#diff-5024b7448f56bf978cf6ef5e933780ebabaf2d2977e6650c3c4df42c484245c4R262-R271)

Enhancements to `MockServer` class:

* Removed redundant `url` property assignment in the `createResponse` method.

Addition of tests for request modes:

* Added tests in `tests/custom-request.test.js` to verify the `mode` property of `CustomRequest` instances.
* Updated the `createRequest` function in `tests/mock-server.test.js` to include the `mode` option.
* Added tests in `tests/mock-server.test.js` to check the response type based on the request mode.