### PR TITLE
fix: Ensure Response#mode is 'cors' when Request#type is 'cors'

### DIFF
--- a/src/custom-request.js
+++ b/src/custom-request.js
@@ -35,6 +35,22 @@ export function createCustomRequest(RequestClass) {
             Object.defineProperty(this, "id", { writable: false });
             
             /*
+             * Default setting for `mode` is "cors" in the fetch API.
+             * Not all runtimes follow the spec, so we need to ensure
+             * that the `mode` property is set correctly.
+             */
+            const expectedMode = init?.mode ?? "cors";
+            
+            if (expectedMode !== this.mode) {
+                Object.defineProperty(this, "mode", {
+                    configurable: true,
+                    enumerable: true,
+                    value: expectedMode,
+                    writable: false,
+                });
+            }
+            
+            /*
              * Not all runtimes properly support the `credentials` property.
 			 * Bun's fetch implementation sets credentials to "include" by default
 			 * and doesn't allow overwriting that value when creating a Request.

--- a/src/fetch-mocker.js
+++ b/src/fetch-mocker.js
@@ -324,6 +324,11 @@ export class FetchMocker {
 			);
 
 			if (response) {
+				// Set response.url and type
+				Object.defineProperties(response, {
+					url: { value: request.url },
+					type: { value: request.mode === "cors" ? "cors" : "default" }
+				});
 				return response;
 			}
 

--- a/src/mock-server.js
+++ b/src/mock-server.js
@@ -512,7 +512,6 @@ export class MockServer {
 				 * need to set it after creating the response.
 				 */
 				const response = await route.createResponse(clonedRequest, PreferredResponse);
-				Object.defineProperty(response, "url", { value: request.url });
 
 				return { response, traces };
 			}

--- a/tests/custom-request.test.js
+++ b/tests/custom-request.test.js
@@ -52,6 +52,12 @@ describe("createCustomRequest()", () => {
         assert.ok(request instanceof Request);
     });
     
+    it("should have a default mode of 'cors'", () => {
+        const request = new CustomRequest(TEST_URL);
+        
+        assert.strictEqual(request.mode, "cors");
+    });
+    
     describe("clone()", () => {
 
         it("should have the same class as the original request", () => {

--- a/tests/fetch-mocker.test.js
+++ b/tests/fetch-mocker.test.js
@@ -2342,4 +2342,53 @@ describe("FetchMocker", () => {
 			);
 		});
 	});
+
+	describe("Response types", () => {
+		it("should set response type to 'cors' when request mode is 'cors'", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server],
+				baseUrl: ALT_BASE_URL
+			});
+			
+			server.get("/hello", {
+				status: 200,
+				headers: {
+					"Access-Control-Allow-Origin": ALT_BASE_URL
+				}
+			});
+
+			const response = await fetchMocker.fetch(API_URL + "/hello", {
+				mode: "cors"
+			});
+			
+			assert.strictEqual(response.type, "cors");
+		});
+
+		it("should set response type to 'cors' when request mode is undefined", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server]
+			});
+			
+			server.get("/hello", 200);
+
+			const response = await fetchMocker.fetch(API_URL + "/hello");
+			assert.strictEqual(response.type, "cors");
+		});
+
+		it("should set response type to 'default' when request mode is 'no-cors'", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server]
+			});
+			
+			server.get("/hello", 200);
+
+			const response = await fetchMocker.fetch(API_URL + "/hello", {
+				mode: "no-cors"
+			});
+			assert.strictEqual(response.type, "default");
+		});
+	});
 });

--- a/tests/mock-server.test.js
+++ b/tests/mock-server.test.js
@@ -246,7 +246,9 @@ describe("MockServer", () => {
 			});
 
 			const response = await server.receive(request);
-			assert.strictEqual(response.url, `${BASE_URL}/test?foo=bar`);
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(response.statusText, "OK");
+			assert.strictEqual(await getResponseBody(response), "OK");
 		});
 
 		it("should delay the response by at least 500ms", async () => {
@@ -258,15 +260,14 @@ describe("MockServer", () => {
 			});
 
 			const startTime = Date.now();
-			const response = await server.receive(request);
+			await server.receive(request);
 			const elapsed = Date.now() - startTime;
 
 			// Note: Bun's clock runs fast so could be a bit under 500ms
 			assert.ok(
 				elapsed >= 475,
 				`Response was delayed ${elapsed}ms, expected at least 500ms.`,
-			);
-			assert.strictEqual(response.url, `${BASE_URL}/test?foo=bar`);
+				);
 		});
 		
 		describe("ResponseCreator Functions", () => {
@@ -286,7 +287,6 @@ describe("MockServer", () => {
 				const response = await server.receive(request);
 				assert.strictEqual(response.status, 200);
 				assert.strictEqual(response.statusText, "OK");
-				assert.strictEqual(response.url, `${BASE_URL}/test?foo=bar`);
 				assert.strictEqual(response.headers.get("custom"), "header");
 				assert.strictEqual(await getResponseBody(response), "Hi");
 			});
@@ -300,7 +300,7 @@ describe("MockServer", () => {
 				});
 
 				const startTime = Date.now();
-				const response = await server.receive(request);
+				await server.receive(request);
 				const elapsed = Date.now() - startTime;
 
 				// Note: Bun's clock runs fast so could be a bit under 500ms
@@ -308,7 +308,6 @@ describe("MockServer", () => {
 					elapsed >= 475,
 					`Response was delayed ${elapsed}ms, expected at least 500ms.`,
 				);
-				assert.strictEqual(response.url, `${BASE_URL}/test?foo=bar`);
 			});
 			
 			it("should pass a Request object to the function", async () => {
@@ -328,8 +327,7 @@ describe("MockServer", () => {
 					url: `${BASE_URL}/test?foo=bar`,
 				});
 
-				const response = await server.receive(request);
-				assert.strictEqual(response.url, `${BASE_URL}/test?foo=bar`);
+				await server.receive(request);
 			});
 			
 		});


### PR DESCRIPTION
This pull request ensures that the `Response#mode` property is properly set to `"cors"` when the `type` property of the `Request` is set to `"cors"`. This also ensures that the default `Response#mode` is `"cors"` per the Fetch API specification (Bun sets it to `"default"`.

The most important changes include setting the `mode` property correctly in the `createCustomRequest` function, updating the `FetchMocker` class to set response properties, and modifying the `MockServer` tests to validate response status and type.

Replaces and closes https://github.com/humanwhocodes/mentoss/pull/57.

### Improvements to `fetch` API handling:

* [`src/custom-request.js`](diffhunk://#diff-3d024b2982939484b878c8446a661b479428d7e4bc40a72140164c7ef7ce0cb9R37-R52): Added logic to set the `mode` property to "cors" by default if not specified, ensuring consistency across different runtimes.
* [`src/fetch-mocker.js`](diffhunk://#diff-09d3018654f9d696c2ce0a5938eb9b5dd6adb822704efafcbfde8b6342f246c5R327-R331): Updated the `FetchMocker` class to set the `url` and `type` properties of the response based on the request's `mode`.

### Updates to test cases:

* [`tests/custom-request.test.js`](diffhunk://#diff-b0ef3f77e45936f710228582cdbabb4884d7c75bef5e28d89ca434811ef037a6R55-R60): Added a test case to verify that the default `mode` of a `CustomRequest` is "cors".
* [`tests/fetch-mocker.test.js`](diffhunk://#diff-c7749aa975a360a952d495ce66db5a38c09de5fa882d6cf00f2a86949208c1b9R2345-R2393): Added test cases to ensure that the response type is set correctly based on the request's `mode`.
* [`tests/mock-server.test.js`](diffhunk://#diff-8ea18cf1c7d7bb1ad2967a064ede011cc0f2b983f81dc73877857d6b379049dfL249-R251): Modified existing tests to validate response status and type instead of the URL, ensuring comprehensive coverage of the new behavior. [[1]](diffhunk://#diff-8ea18cf1c7d7bb1ad2967a064ede011cc0f2b983f81dc73877857d6b379049dfL249-R251) [[2]](diffhunk://#diff-8ea18cf1c7d7bb1ad2967a064ede011cc0f2b983f81dc73877857d6b379049dfL261-L269) [[3]](diffhunk://#diff-8ea18cf1c7d7bb1ad2967a064ede011cc0f2b983f81dc73877857d6b379049dfL289) [[4]](diffhunk://#diff-8ea18cf1c7d7bb1ad2967a064ede011cc0f2b983f81dc73877857d6b379049dfL303-L311) [[5]](diffhunk://#diff-8ea18cf1c7d7bb1ad2967a064ede011cc0f2b983f81dc73877857d6b379049dfL331-R330)