### PR TITLE
feat: Implement fetch with mode: "same-origin"

### DIFF
--- a/src/fetch-mocker.js
+++ b/src/fetch-mocker.js
@@ -239,6 +239,7 @@ export class FetchMocker {
 					: input;
 
 			const request = new this.#Request(fixedInput, init);
+
 			let useCors = false;
 			let useCorsCredentials = false;
 			let preflightData;
@@ -254,6 +255,14 @@ export class FetchMocker {
 						this.#attachCredentialsToRequest(request);
 					}
 				} else {
+										
+					// check for same-origin mode
+					if (request.mode === "same-origin") {
+						throw new TypeError(
+							`Failed to fetch. Request mode is "same-origin" but the URL's origin is not same as the request origin ${this.#baseUrl.origin}`
+						);
+					}
+
 					useCors = true;
 					isSimpleRequest = isCorsSimpleRequest(request);
 					const includeCredentials =


### PR DESCRIPTION
This pull request implements ["same-origin" mode](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#mode) mocking for `fetch()`. This ensures that requests like this correctly fail when making a cross-origin request:

```js
const response = await fetch("https://example.com/foo", { mode: "same-origin" });
```

The correct behavior is to throw a `TypeError` for any URLs that are not of the same origin.

### Enhancements to `FetchMocker`:

* Added a check for `same-origin` mode in the `FetchMocker` class to throw a `TypeError` if the request origin does not match the URL's origin.

### Tests for `same-origin` mode:

* Added a new test case to ensure a `TypeError` is thrown when a request with `mode=same-origin` is made to a different origin.
* Added a new test case to verify that a request with `mode=same-origin` succeeds when the request origin matches the URL's origin.