### PR TITLE
fix: Ensure baseUrl is properly applied to route matching

### DIFF
--- a/src/request-matcher.js
+++ b/src/request-matcher.js
@@ -106,7 +106,19 @@ export class RequestMatcher {
 		params,
 	}) {
 		this.#method = method;
-		this.#pattern = new URLPattern(url, baseUrl);
+		
+		/*
+		 * URLPattern treats a leading slash as being an absolute path from
+		 * the domain in the base URL (if present). So if the URL is /api
+		 * and the base URL is https://example.com/v1, the URLPattern will
+		 * match https://example.com/api. To avoid this, we remove the leading
+		 * slash from the URL if it's present and add a trailing slash to the
+		 * base URL if it's not present.
+		 */
+		this.#pattern = new URLPattern(
+			url.startsWith("/") ? url.slice(1) : url,
+			!baseUrl || baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`
+		);
 		this.#body = body;
 		this.#headers = headers;
 		this.#query = query;

--- a/tests/request-matcher.test.js
+++ b/tests/request-matcher.test.js
@@ -99,6 +99,86 @@ describe("RequestMatcher", () => {
 
 			assert.strictEqual(matcher.matches(request), true);
 		});
+		
+		it("should match requests when URL pattern starts with / and baseUrl ends with /", () => {
+			const matcher = new RequestMatcher({
+				method: "GET",
+				baseUrl: `${BASE_URL}/`,
+				url: `/users/:id`,
+			});
+			
+			const request = {
+				method: "GET",
+				url: `${BASE_URL}/users/123`,
+				headers: {},
+			};
+			
+			assert.strictEqual(matcher.matches(request), true);
+		});
+		
+		it("should match requests when URL pattern starts with / and baseUrl has a path and ends with /", () => {
+			const matcher = new RequestMatcher({
+				method: "GET",
+				baseUrl: `${BASE_URL}/users/`,
+				url: `/:id`,
+			});
+
+			const request = {
+				method: "GET",
+				url: `${BASE_URL}/users/123`,
+				headers: {},
+			};
+
+			assert.strictEqual(matcher.matches(request), true);
+		});		
+
+		it("should match requests when URL pattern doesn't start with / and baseUrl has a path and ends with /", () => {
+			const matcher = new RequestMatcher({
+				method: "GET",
+				baseUrl: `${BASE_URL}/users/`,
+				url: `:id`,
+			});
+
+			const request = {
+				method: "GET",
+				url: `${BASE_URL}/users/123`,
+				headers: {},
+			};
+
+			assert.strictEqual(matcher.matches(request), true);
+		});		
+
+		it("should match requests when URL pattern starts with / and baseUrl has a path and doesn't end with /", () => {
+			const matcher = new RequestMatcher({
+				method: "GET",
+				baseUrl: `${BASE_URL}/users`,
+				url: `/:id`,
+			});
+
+			const request = {
+				method: "GET",
+				url: `${BASE_URL}/users/123`,
+				headers: {},
+			};
+
+			assert.strictEqual(matcher.matches(request), true);
+		});		
+
+		it("should match requests when URL pattern doesn't start with / and baseUrl has a path and doesn't end with /", () => {
+			const matcher = new RequestMatcher({
+				method: "GET",
+				baseUrl: `${BASE_URL}/users`,
+				url: `:id`,
+			});
+
+			const request = {
+				method: "GET",
+				url: `${BASE_URL}/users/123`,
+				headers: {},
+			};
+
+			assert.strictEqual(matcher.matches(request), true);
+		});		
 
 		it("should match requests with matching headers", () => {
 			const matcher = new RequestMatcher({


### PR DESCRIPTION
This pull request improves the `RequestMatcher` class to handle URL patterns more robustly and adds comprehensive tests to ensure the new behavior is correct. The most important changes include modifying the URL pattern handling logic and adding multiple test cases to cover various scenarios.

URLPattern treats a leading slash as being an absolute path from the domain in the base URL (if present). So if the URL is /api and the base URL is https://example.com/v1, the URLPattern will match https://example.com/api. To avoid this, we remove the leading slash from the URL if it's present and add a trailing slash to the base URL if it's not present.

Enhancements to URL pattern handling:

* [`src/request-matcher.js`](diffhunk://#diff-a93d71985d250aedffbf5ca474e5df23cf3e882b3de1ea4cd1d5967f72ddf1d8L109-R121): Updated the URL pattern logic to ensure leading slashes in URLs are handled correctly and base URLs are normalized with trailing slashes if necessary. This prevents mismatches when combining URLs and base URLs.

Additional test cases:

* [`tests/request-matcher.test.js`](diffhunk://#diff-48d6d85331636a4be076ffe3c924c1ffa2775273558263427cca0013e188f4f3R103-R182): Added multiple test cases to verify that the `RequestMatcher` correctly matches requests when URL patterns and base URLs have different combinations of leading and trailing slashes. These tests ensure that the new URL pattern handling logic works as intended in various scenarios.