### PR TITLE
feat: export types for use downstream

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,3 +7,4 @@
 export { MockServer } from "./mock-server.js";
 export { FetchMocker } from "./fetch-mocker.js";
 export { CookieCredentials } from "./cookie-credentials.js";
+export * from "./types.js";


### PR DESCRIPTION
I would like to use the `RequestPattern`  type as part of my test utils. Seems like exporting the types file could be nice for other folks too. 

Other alternatives might be tweaking the package.json to expose the type file in the exports. Thanks for the awesome repo, I am really liking it.