### PR TITLE
fix: More succinct message when no partial matches found

### DIFF
--- a/src/fetch-mocker.js
+++ b/src/fetch-mocker.js
@@ -49,20 +49,21 @@ Full Request:
 
 ${stringifyRequest(request, body)}
 
-Partial matches:
-
 ${
-	traces
-		.map(trace => {
-			let traceMessage = `${trace.title}:`;
+	traces.length === 0
+		? "No partial matches found."
+		: "Partial matches:\n\n" +
+		  traces
+				.map(trace => {
+					let traceMessage = `${trace.title}:`;
 
-			trace.messages.forEach(message => {
-				traceMessage += `\n  ${message}`;
-			});
+					trace.messages.forEach(message => {
+						traceMessage += `\n  ${message}`;
+					});
 
-			return traceMessage;
-		})
-		.join("\n\n") || "No partial matches found."
+					return traceMessage;
+				})
+				.join("\n\n")
 }`;
 }
 

--- a/tests/fetch-mocker.test.js
+++ b/tests/fetch-mocker.test.js
@@ -33,8 +33,6 @@ Full Request:
 
 GET https://api.example.com/goodbye
 
-Partial matches:
-
 No partial matches found.`.trim();
 
 const NO_ROUTE_MATCHED_TWO_PARTIAL_MATCHES = `


### PR DESCRIPTION
Previously, when there were no partial matches found the error message would say "Partial matches found: No partial matches". This shortens it to just "No partial matches."

* [`src/fetch-mocker.js`](diffhunk://#diff-09d3018654f9d696c2ce0a5938eb9b5dd6adb822704efafcbfde8b6342f246c5L52-R55): Changed the message to "No partial matches found." when `traces.length` is zero, and adjusted the formatting of partial match messages. [[1]](diffhunk://#diff-09d3018654f9d696c2ce0a5938eb9b5dd6adb822704efafcbfde8b6342f246c5L52-R55) [[2]](diffhunk://#diff-09d3018654f9d696c2ce0a5938eb9b5dd6adb822704efafcbfde8b6342f246c5L65-R66)

Updates to test cases:

* [`tests/fetch-mocker.test.js`](diffhunk://#diff-c7749aa975a360a952d495ce66db5a38c09de5fa882d6cf00f2a86949208c1b9L36-L37): Updated the test case to reflect the new message format for no partial matches.