### PR TITLE
feat: Match against already-called routes for better errors

### DIFF
--- a/src/mock-server.js
+++ b/src/mock-server.js
@@ -550,6 +550,22 @@ export class MockServer {
 			traces.push({ ...trace, title: route.toString() });
 		}
 
+		/*
+		 * If we made it here, then no route matched the request. We need to
+		 * now check if any called routes match the request and produce a trace
+		 * for each of them.
+		 */
+		const matchedRoutes = this.#matchedRoutes;
+		
+		for (let i = 0; i < matchedRoutes.length; i++) {
+			const route = matchedRoutes[i];
+			const trace = route.traceMatches(requestPattern);
+			
+			trace.messages.push("❌ Route was already called.");
+			
+			traces.push({ ...trace, title: route.toString() });
+		}
+		
 		return { response: undefined, traces };
 	}
 


### PR DESCRIPTION
This adds the ability for Mentoss to check already-called routes in addition to uncalled routes. This helps when a request is meant to match a route that has been registered, but doesn't because the route already matched a previous request, removing it from consideration.

When there isn't a match in uncalled routes, MockServer will now continue on to check called routes and return any that match with the note that it has already been matched and that's why it's not used.

Enhancements to tracing functionality:

* [`src/mock-server.js`](diffhunk://#diff-5024b7448f56bf978cf6ef5e933780ebabaf2d2977e6650c3c4df42c484245c4R553-R568): Added logic to check if any called routes match the request and produce a trace for each of them, including a message indicating that the route was already called.

Updates to test suite:

* [`tests/mock-server.test.js`](diffhunk://#diff-8ea18cf1c7d7bb1ad2967a064ede011cc0f2b983f81dc73877857d6b379049dfR646-R684): Added a new test case to ensure that traces are correctly generated when uncalled routes do not match but a called route does match, including verifying the trace messages and titles.