### PR TITLE
fix: Ensure ArrayBuffer is passed throughto response

### DIFF
--- a/src/mock-server.js
+++ b/src/mock-server.js
@@ -256,7 +256,7 @@ export class Route {
 		}
 
 		// if the body is an object, return JSON
-		if (typeof body === "object") {
+		if (typeof body === "object" && body.constructor === Object) {
 			return new PreferredResponse(JSON.stringify(body), {
 				...init,
 				statusText,

--- a/src/mock-server.js
+++ b/src/mock-server.js
@@ -256,7 +256,7 @@ export class Route {
 		}
 
 		// if the body is an object, return JSON
-		if (typeof body === "object" && body.constructor === Object) {
+		if (body && typeof body === "object" && body.constructor === Object) {
 			return new PreferredResponse(JSON.stringify(body), {
 				...init,
 				statusText,

--- a/tests/mock-server.test.js
+++ b/tests/mock-server.test.js
@@ -271,6 +271,28 @@ describe("MockServer", () => {
 				`Response was delayed ${elapsed}ms, expected at least 500ms.`,
 			);
 		});
+		
+		it("should return an ArrayBuffer when response body is an ArrayBuffer", async () => {
+			
+			const requestBody = new Uint8Array([1, 2, 3, 4, 5]);
+			
+			server.get("/test", {
+				status: 200,
+				body: requestBody.buffer,
+			});
+			
+			const request = createRequest({
+				method: "GET",
+				url: `${BASE_URL}/test`,
+			});
+			
+			const response = await server.receive(request);
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(response.statusText, "OK");
+			
+			const responseBody = new Uint8Array(await getResponseBody(response));
+			assert.deepEqual(responseBody, requestBody);
+		});
 
 		describe("ResponseCreator Functions", () => {
 			afterEach(() => {


### PR DESCRIPTION
This pull request includes changes to the `src/mock-server.js` and `tests/mock-server.test.js` files to improve the handling and testing of response bodies in the mock server.

fixes #89

Improvements to response body handling:

* [`src/mock-server.js`](diffhunk://#diff-5024b7448f56bf978cf6ef5e933780ebabaf2d2977e6650c3c4df42c484245c4L259-R259): Modified the condition to check if the body is a plain object by adding an additional check for the constructor property.

Enhancements to testing:

* [`tests/mock-server.test.js`](diffhunk://#diff-8ea18cf1c7d7bb1ad2967a064ede011cc0f2b983f81dc73877857d6b379049dfR275-R296): Added a new test case to verify that the mock server correctly returns an `ArrayBuffer` when the response body is an `ArrayBuffer`.