### PR TITLE
chore: reuse fetch method

### DIFF
--- a/src/custom-request.js
+++ b/src/custom-request.js
@@ -61,14 +61,14 @@ export function createCustomRequest(RequestClass) {
 					writable: false,
 				});
 			}
-			
+
 			/*
 			 * Default setting for `redirect` is "follow" in the fetch API.
 			 * Not all runtimes follow the spec, so we need to ensure
 			 * that the `redirect` property is set correctly.
 			 */
 			const expectedRedirect = init?.redirect ?? "follow";
-			
+
 			if (expectedRedirect !== this.redirect) {
 				Object.defineProperty(this, "redirect", {
 					configurable: true,

--- a/src/fetch-mocker.js
+++ b/src/fetch-mocker.js
@@ -24,11 +24,11 @@ import {
 	createCorsError,
 } from "./cors.js";
 import { createCustomRequest } from "./custom-request.js";
-import { 
-	isRedirectStatus, 
-	isBodylessMethod, 
+import {
+	isRedirectStatus,
+	isBodylessMethod,
 	isBodyPreservingRedirectStatus,
-	isRequestBodyHeader
+	isRequestBodyHeader,
 } from "./http.js";
 
 //-----------------------------------------------------------------------------
@@ -175,12 +175,12 @@ function createOpaqueRedirectResponse(ResponseConstructor, url) {
  * @returns {boolean} True if the redirect needs to adjust the method
  */
 function redirectNeedsAdjustment(request, status) {
-	
 	// For 303 redirects, change method to GET if it's not already GET or HEAD
-	return status === 303 && !isBodylessMethod(request.method) ||
-
+	return (
+		(status === 303 && !isBodylessMethod(request.method)) ||
 		// For 301/302 redirects, change method to GET if the original method was POST
-		(status === 301 || status === 302) && request.method === "POST";
+		((status === 301 || status === 302) && request.method === "POST")
+	);
 }
 
 /**
@@ -245,105 +245,104 @@ export class FetchMocker {
 	/**
 	 * @type {typeof fetch}
 	 */
-  async #fetch(input, init) {
-    // first check to see if the request has been aborted
-    const signal = init?.signal;
-    signal?.throwIfAborted();
+	async #fetch(input, init) {
+		// first check to see if the request has been aborted
+		const signal = init?.signal;
+		signal?.throwIfAborted();
 
-    // TODO: For some reason this causes Mocha tests to fail with "multiple done"
-    // signal?.addEventListener("abort", () => {
-    // 	throw new Error("Fetch was aborted.");
-    // });
+		// TODO: For some reason this causes Mocha tests to fail with "multiple done"
+		// signal?.addEventListener("abort", () => {
+		// 	throw new Error("Fetch was aborted.");
+		// });
 
-    // adjust any relative URLs
-    const fixedInput =
-      typeof input === "string" && this.#baseUrl
-        ? new URL(input, this.#baseUrl).toString()
-        : input;
+		// adjust any relative URLs
+		const fixedInput =
+			typeof input === "string" && this.#baseUrl
+				? new URL(input, this.#baseUrl).toString()
+				: input;
 
-    const request = new this.#Request(fixedInput, init);
+		const request = new this.#Request(fixedInput, init);
 
-    let useCors = false;
-    let useCorsCredentials = false;
-    let preflightData;
-    let isSimpleRequest = false;
+		let useCors = false;
+		let useCorsCredentials = false;
+		let preflightData;
+		let isSimpleRequest = false;
 
-    // if there's a base URL then we need to check for CORS
-    if (this.#baseUrl) {
-      const requestUrl = new URL(request.url);
+		// if there's a base URL then we need to check for CORS
+		if (this.#baseUrl) {
+			const requestUrl = new URL(request.url);
 
-      if (isSameOrigin(requestUrl, this.#baseUrl)) {
-        // if we aren't explicitly blocking credentials then add them
-        if (request.credentials !== "omit") {
-          this.#attachCredentialsToRequest(request);
-        }
-      } else {
-        // check for same-origin mode
-        if (request.mode === "same-origin") {
-          throw new TypeError(
-            `Failed to fetch. Request mode is "same-origin" but the URL's origin is not same as the request origin ${this.#baseUrl.origin}`,
-          );
-        }
+			if (isSameOrigin(requestUrl, this.#baseUrl)) {
+				// if we aren't explicitly blocking credentials then add them
+				if (request.credentials !== "omit") {
+					this.#attachCredentialsToRequest(request);
+				}
+			} else {
+				// check for same-origin mode
+				if (request.mode === "same-origin") {
+					throw new TypeError(
+						`Failed to fetch. Request mode is "same-origin" but the URL's origin is not same as the request origin ${this.#baseUrl.origin}`,
+					);
+				}
 
-        useCors = true;
-        isSimpleRequest = isCorsSimpleRequest(request);
-        const includeCredentials =
-          request.credentials === "include";
+				useCors = true;
+				isSimpleRequest = isCorsSimpleRequest(request);
+				const includeCredentials = request.credentials === "include";
 
-        validateCorsRequest(request, this.#baseUrl.origin);
+				validateCorsRequest(request, this.#baseUrl.origin);
 
-        if (isSimpleRequest) {
-          if (includeCredentials) {
-            useCorsCredentials = true;
-            this.#attachCredentialsToRequest(request);
-          }
-        } else {
-          preflightData = await this.#preflightFetch(request);
-          preflightData.validate(request, this.#baseUrl.origin);
+				if (isSimpleRequest) {
+					if (includeCredentials) {
+						useCorsCredentials = true;
+						this.#attachCredentialsToRequest(request);
+					}
+				} else {
+					preflightData = await this.#preflightFetch(request);
+					preflightData.validate(request, this.#baseUrl.origin);
 
-          if (includeCredentials) {
-            if (!preflightData.allowCredentials) {
-              throw createCorsPreflightError(
-                request.url,
-                this.#baseUrl.origin,
-                "No 'Access-Control-Allow-Credentials' header is present on the requested resource.",
-              );
-            }
+					if (includeCredentials) {
+						if (!preflightData.allowCredentials) {
+							throw createCorsPreflightError(
+								request.url,
+								this.#baseUrl.origin,
+								"No 'Access-Control-Allow-Credentials' header is present on the requested resource.",
+							);
+						}
 
-            useCorsCredentials = true;
-            this.#attachCredentialsToRequest(request);
-          }
-        }
+						useCorsCredentials = true;
+						this.#attachCredentialsToRequest(request);
+					}
+				}
 
-        // add the origin header to the request
-        request.headers.append("origin", this.#baseUrl.origin);
+				// add the origin header to the request
+				request.headers.append("origin", this.#baseUrl.origin);
 
-        // if the preflight response is successful, then we can make the actual request
-      }
-    }
+				// if the preflight response is successful, then we can make the actual request
+			}
+		}
 
-    signal?.throwIfAborted();
+		signal?.throwIfAborted();
 
-    const response = await this.#internalFetch(request, init?.body);
+		const response = await this.#internalFetch(request, init?.body);
 
-    if (useCors && this.#baseUrl) {
-      // handle no-cors mode for any cross-origin request
-      if (isSimpleRequest && request.mode === "no-cors") {
-        return createOpaqueResponse(this.#Response);
-      }
+		if (useCors && this.#baseUrl) {
+			// handle no-cors mode for any cross-origin request
+			if (isSimpleRequest && request.mode === "no-cors") {
+				return createOpaqueResponse(this.#Response);
+			}
 
-      processCorsResponse(
-        response,
-        this.#baseUrl.origin,
-        useCorsCredentials,
-      );
-    }
+			processCorsResponse(
+				response,
+				this.#baseUrl.origin,
+				useCorsCredentials,
+			);
+		}
 
-    signal?.throwIfAborted();
+		signal?.throwIfAborted();
 
-    // Process redirects
-    return this.#processRedirect(response, request, [], init?.body);
-  };
+		// Process redirects
+		return this.#processRedirect(response, request, [], init?.body);
+	}
 
 	/**
 	 * Map to store original fetch functions for objects
@@ -544,10 +543,15 @@ export class FetchMocker {
 	 * @returns {Promise<Response>} The final response after any redirects
 	 * @see https://fetch.spec.whatwg.org/#http-redirect-fetch
 	 */
-	async #processRedirect(response, request, urlList = [], requestBody = null) {
+	async #processRedirect(
+		response,
+		request,
+		urlList = [],
+		requestBody = null,
+	) {
 		// Add current URL to list
 		urlList.push(new URL(request.url));
-		
+
 		const isRedirect = isRedirectStatus(response.status);
 
 		// Process response based on redirect status and mode
@@ -558,27 +562,34 @@ export class FetchMocker {
 			}
 			return response;
 		}
-		
+
 		// Handle based on redirect mode
 		switch (request.redirect) {
 			case "manual":
 				// Return an opaque redirect response
-				return createOpaqueRedirectResponse(this.#Response, request.url);
-				
+				return createOpaqueRedirectResponse(
+					this.#Response,
+					request.url,
+				);
+
 			case "error":
 				// Just throw an error
-				throw new TypeError(`Redirect at ${request.url} was blocked due to redirect mode being 'error'`);
-				
+				throw new TypeError(
+					`Redirect at ${request.url} was blocked due to redirect mode being 'error'`,
+				);
+
 			case "follow":
 			default:
 				// Continue with redirect handling
 				break;
 		}
-		
+
 		// Get and validate the redirect location
 		const location = response.headers.get("Location");
 		if (!location) {
-			throw new TypeError(`Redirect at ${request.url} has no Location header`);
+			throw new TypeError(
+				`Redirect at ${request.url} has no Location header`,
+			);
 		}
 
 		// Construct the new URL
@@ -591,21 +602,23 @@ export class FetchMocker {
 
 		// Check for redirect loops
 		if (urlList.some(url => url.href === redirectUrl.href)) {
-			throw new TypeError(`Redirect loop detected for ${redirectUrl.href}`);
+			throw new TypeError(
+				`Redirect loop detected for ${redirectUrl.href}`,
+			);
 		}
 
 		// Check redirect limit
 		if (urlList.length >= 20) {
 			throw new TypeError("Too many redirects (maximum is 20)");
 		}
-		
+
 		let method = request.method;
 		const headers = new Headers(request.headers);
-		
+
 		// If this is a redirect that changes the method, adjust accordingly
 		if (redirectNeedsAdjustment(request, response.status)) {
 			method = "GET";
-			
+
 			for (const header of headers.keys()) {
 				// Remove headers that should not be sent with GET requests
 				if (isRequestBodyHeader(header)) {
@@ -613,7 +626,7 @@ export class FetchMocker {
 				}
 			}
 		}
-		
+
 		// Create a new request for the redirect
 		const init = {
 			method,
@@ -625,41 +638,58 @@ export class FetchMocker {
 			referrerPolicy: request.referrerPolicy,
 			signal: request.signal,
 			keepalive: request.keepalive,
-			body: null
+			body: null,
 		};
-		
+
 		// Determine if we should preserve the body (307/308 redirects)
-		const preserveBodyStatus = isBodyPreservingRedirectStatus(response.status);
-		
-		if (preserveBodyStatus && requestBody !== null && !isBodylessMethod(method)) {
+		const preserveBodyStatus = isBodyPreservingRedirectStatus(
+			response.status,
+		);
+
+		if (
+			preserveBodyStatus &&
+			requestBody !== null &&
+			!isBodylessMethod(method)
+		) {
 			init.body = requestBody;
 		}
 
 		// Check if this is a cross-origin redirect
 		const currentOrigin = new URL(request.url).origin;
-		const isCrossOrigin = this.#baseUrl && 
-			redirectUrl.origin !== currentOrigin;
+		const isCrossOrigin =
+			this.#baseUrl && redirectUrl.origin !== currentOrigin;
 
 		if (isCrossOrigin) {
 			// For non-same-origin redirect, remove authorization header
 			init.headers.delete("authorization");
-			
+
 			// For cross-origin redirect with credentials, check for CORS issues
-			if (request.credentials === "include" && !isTaintedResponse(response)) {
+			if (
+				request.credentials === "include" &&
+				!isTaintedResponse(response)
+			) {
 				throw createCorsError(
 					redirectUrl.href,
 					this.#baseUrl?.origin || "",
-					"Cross-origin redirect with credentials is not allowed"
+					"Cross-origin redirect with credentials is not allowed",
 				);
 			}
 		}
 
 		// Make the new request
 		const redirectRequest = new this.#Request(redirectUrl.href, init);
-		const redirectResponse = await this.#internalFetch(redirectRequest, init.body);
-		
+		const redirectResponse = await this.#internalFetch(
+			redirectRequest,
+			init.body,
+		);
+
 		// Process further redirects recursively
-		return this.#processRedirect(redirectResponse, redirectRequest, urlList, init.body);
+		return this.#processRedirect(
+			redirectResponse,
+			redirectRequest,
+			urlList,
+			init.body,
+		);
 	}
 
 	// #region: Testing Helpers

--- a/tests/custom-request.test.js
+++ b/tests/custom-request.test.js
@@ -73,9 +73,8 @@ describe("createCustomRequest()", () => {
 			}, /Header 'X-Custom-Header' is not allowed in 'no-cors' mode/);
 		});
 	});
-	
+
 	describe("redirect", () => {
-		
 		it("should have a default redirect mode of 'follow'", () => {
 			const request = new CustomRequest(TEST_URL);
 

--- a/tests/redirect.test.js
+++ b/tests/redirect.test.js
@@ -24,597 +24,627 @@ const ALT_BASE_URL = "https://api.example.org";
 //-----------------------------------------------------------------------------
 
 describe("Redirect Tests", () => {
-    describe("Same-Origin Redirects", () => {
-        it("should follow a 301 redirect and change method from POST to GET", async () => {
-            const server = new MockServer(API_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server],
-                baseUrl: API_URL,
-            });
-
-            server.post("/original", {
-                status: 301,
-                headers: {
-                    "Location": "/redirected"
-                }
-            });
-
-            server.get("/redirected", {
-                status: 200,
-                body: "Redirected content"
-            });
-
-            const response = await fetchMocker.fetch("/original", {
-                method: "POST",
-                body: JSON.stringify({ data: "test" })
-            });
-
-            assert.strictEqual(response.status, 200);
-            assert.strictEqual(await response.text(), "Redirected content");
-            assert.strictEqual(response.redirected, true);
-        });
-
-        it("should follow a 302 redirect and change method from POST to GET", async () => {
-            const server = new MockServer(API_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server],
-                baseUrl: API_URL,
-            });
-
-            server.post("/original", {
-                status: 302,
-                headers: {
-                    "Location": "/redirected"
-                }
-            });
-
-            server.get("/redirected", {
-                status: 200,
-                body: "Redirected content"
-            });
-
-            const response = await fetchMocker.fetch("/original", {
-                method: "POST",
-                body: JSON.stringify({ data: "test" })
-            });
-
-            assert.strictEqual(response.status, 200);
-            assert.strictEqual(await response.text(), "Redirected content");
-            assert.strictEqual(response.redirected, true);
-        });
-
-        it("should follow a 303 redirect and always change method to GET", async () => {
-            const server = new MockServer(API_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server],
-                baseUrl: API_URL,
-            });
-
-            server.put("/original", {
-                status: 303,
-                headers: {
-                    "Location": "/redirected"
-                }
-            });
-
-            server.get("/redirected", {
-                status: 200,
-                body: "Redirected content"
-            });
-
-            const response = await fetchMocker.fetch("/original", {
-                method: "PUT",
-                body: JSON.stringify({ data: "test" })
-            });
-
-            assert.strictEqual(response.status, 200);
-            assert.strictEqual(await response.text(), "Redirected content");
-            assert.strictEqual(response.redirected, true);
-        });
-
-        it("should follow a 307 redirect and preserve the original method and body", async () => {
-            const server = new MockServer(API_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server],
-                baseUrl: API_URL,
-            });
-
-            server.post("/original", {
-                status: 307,
-                headers: {
-                    "Location": "/redirected"
-                }
-            });
-
-            // Modify how we handle the body in the response handler
-            server.post(
-                {
-                    url: "/redirected",
-                    body: {
-                        "data": "test"
-                    }
-                },
-                {
-                    status: 200,
-                    body: "Got request with body: {\"data\":\"test\"}"
-                }
-            );
-
-            const response = await fetchMocker.fetch("/original", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ data: "test" })
-            });
-
-            assert.strictEqual(response.status, 200);
-            assert.strictEqual(await response.text(), "Got request with body: {\"data\":\"test\"}");
-            assert.strictEqual(response.redirected, true);
-        });
-
-        it("should follow a 308 redirect and preserve the original method and body", async () => {
-            const server = new MockServer(API_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server],
-                baseUrl: API_URL,
-            });
-
-            server.post("/original", {
-                status: 308,
-                headers: {
-                    "Location": "/redirected"
-                }
-            });
-
-            // Modify how we handle the body in the response handler
-            server.post(
-                {
-                    url: "/redirected",
-                    body: {
-                        "data": "test"
-                    }
-                },
-                {
-                    status: 200,
-                    body: "Got request with body: {\"data\":\"test\"}"
-                }
-            );
-
-            const response = await fetchMocker.fetch("/original", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ data: "test" })
-            });
-
-            assert.strictEqual(response.status, 200);
-            assert.strictEqual(await response.text(), "Got request with body: {\"data\":\"test\"}");
-            assert.strictEqual(response.redirected, true);
-        });
-
-        it("should not follow a redirect when redirect mode is 'error'", async () => {
-            const server = new MockServer(API_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server],
-                baseUrl: API_URL,
-            });
-
-            server.get("/original", {
-                status: 301,
-                headers: {
-                    "Location": "/redirected"
-                }
-            });
-
-            server.get("/redirected", {
-                status: 200,
-                body: "Redirected content"
-            });
-
-            await assert.rejects(
-                fetchMocker.fetch("/original", { redirect: "error" }),
-                error => error instanceof TypeError && /redirect mode being 'error'/.test(error.message)
-            );
-        });
-
-        it("should return an opaque redirect response when redirect mode is 'manual'", async () => {
-            const server = new MockServer(API_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server],
-                baseUrl: API_URL,
-            });
-
-            server.get("/original", {
-                status: 301,
-                headers: {
-                    "Location": "/redirected"
-                }
-            });
-
-            const response = await fetchMocker.fetch("/original", { redirect: "manual" });
-            
-            assert.strictEqual(response.type, "opaqueredirect");
-            assert.strictEqual(response.status, 0);
-            assert.strictEqual(response.url, API_URL + "/original");
-        });
-
-        it("should detect and prevent redirect loops", async () => {
-            const server = new MockServer(API_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server],
-                baseUrl: API_URL,
-            });
-
-            server.get("/original", {
-                status: 302,
-                headers: {
-                    "Location": "/loop"
-                }
-            });
-
-            server.get("/loop", {
-                status: 302,
-                headers: {
-                    "Location": "/original"
-                }
-            });
-
-            await assert.rejects(
-                fetchMocker.fetch("/original"),
-                error => error instanceof TypeError && /Redirect loop detected/.test(error.message)
-            );
-        });
-
-        it("should throw an error when redirect limit is exceeded", async () => {
-            const server = new MockServer(API_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server],
-                baseUrl: API_URL,
-            });
-
-            // Setup 21 redirects (more than the 20 limit)
-            for (let i = 0; i < 21; i++) {
-                server.get(`/redirect${i}`, {
-                    status: 302,
-                    headers: {
-                        "Location": i < 20 ? `/redirect${i + 1}` : "/final"
-                    }
-                });
-            }
-
-            server.get("/final", {
-                status: 200,
-                body: "Final destination"
-            });
-
-            await assert.rejects(
-                fetchMocker.fetch("/redirect0"),
-                error => error instanceof TypeError && /Too many redirects/.test(error.message)
-            );
-        });
-        
-        it("should change the method to GET on 301 redirects with a body", async () => {
-            const server = new MockServer(API_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server],
-                baseUrl: API_URL,
-            });
-
-            server.post("/original", {
-                status: 301,
-                headers: {
-                    "Location": "/redirected"
-                }
-            });
-
-            server.get("/redirected", {
-                status: 200,
-                body: "Redirected content"
-            });
-
-            const response = await fetchMocker.fetch("/original", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({ data: "test" })
-            });
-
-            assert.strictEqual(response.status, 200);
-            assert.strictEqual(await response.text(), "Redirected content");
-            assert.strictEqual(response.redirected, true);
-        });
-        
-        it("should change the method to GET on 302 redirects with a body", async () => {
-            const server = new MockServer(API_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server],
-                baseUrl: API_URL,
-            });
-            server.post("/original", {
-                status: 302,
-                headers: {
-                    "Location": "/redirected"
-                }
-            });
-            server.get("/redirected", {
-                status: 200,
-                body: "Redirected content"
-            });
-            const response = await fetchMocker.fetch("/original", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json"
-                },                
-                body: JSON.stringify({ data: "test" })
-            });
-            assert.strictEqual(response.status, 200);
-            assert.strictEqual(await response.text(), "Redirected content");
-            assert.strictEqual(response.redirected, true);
-        });
-        
-        it("should change the method to GET on 303 redirects with a body", async () => {
-            const server = new MockServer(API_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server],
-                baseUrl: API_URL,
-            });
-            server.put("/original", {
-                status: 303,
-                headers: {
-                    "Location": "/redirected"
-                }
-            });
-            server.get("/redirected", {
-                status: 200,
-                body: "Redirected content"
-            });
-            const response = await fetchMocker.fetch("/original", {
-                method: "PUT",
-                headers: {
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({ data: "test" })
-            });
-            assert.strictEqual(response.status, 200);
-            assert.strictEqual(await response.text(), "Redirected content");
-            assert.strictEqual(response.redirected, true);
-        });
-        
-        it("should delete the content-type header on 301 redirects with a body", async () => {
-            const server = new MockServer(API_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server],
-                baseUrl: API_URL,
-            });
-
-            server.post("/original", {
-                status: 301,
-                headers: {
-                    "Location": "/redirected"
-                }
-            });
-
-            // this should not be called
-            server.get(
-                {
-                    url: "/redirected",
-                    headers: {
-                        "Content-Type": "application/json"
-                    },
-                },
-                {
-                    status: 200,
-                    body: "Invalid redirected content"
-                }
-            );
-            
-            server.get("/redirected", {
-                status: 200,
-                body: "Redirected content"
-            });
-
-            const response = await fetchMocker.fetch("/original", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({ data: "test" })
-            });
-
-            assert.strictEqual(response.status, 200);
-            assert.strictEqual(await response.text(), "Redirected content");
-            assert.strictEqual(response.redirected, true);
-        });
-        
-        it("should delete the content-type header on 303 redirects with a body", async () => {
-            const server = new MockServer(API_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server],
-                baseUrl: API_URL,
-            });
-
-            server.put("/original", {
-                status: 303,
-                headers: {
-                    "Location": "/redirected"
-                }
-            });
-
-            // this should not be called
-            server.get(
-                {
-                    url: "/redirected",
-                    headers: {
-                        "Content-Type": "application/json"
-                    },
-                },
-                {
-                    status: 200,
-                    body: "Invalid redirected content"
-                }
-            );
-
-            server.get("/redirected", {
-                status: 200,
-                body: "Redirected content"
-            });
-
-            const response = await fetchMocker.fetch("/original", {
-                method: "PUT",
-                headers: {
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({ data: "test" })
-            });
-
-            assert.strictEqual(response.status, 200);
-            assert.strictEqual(await response.text(), "Redirected content");
-            assert.strictEqual(response.redirected, true);
-        });
-        
-        it("should not change the method to GET on 307 redirects with a body", async () => {
-            const server = new MockServer(API_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server],
-                baseUrl: API_URL,
-            });
-
-            server.post("/original", {
-                status: 307,
-                headers: {
-                    "Location": "/redirected"
-                }
-            });
-
-            // Modify how we handle the body in the response handler
-            server.post(
-                {
-                    url: "/redirected",
-                    body: {
-                        "data": "test"
-                    }
-                },
-                {
-                    status: 200,
-                    body: "Got request with body: {\"data\":\"test\"}"
-                }
-            );
-
-            const response = await fetchMocker.fetch("/original", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ data: "test" })
-            });
-
-            assert.strictEqual(response.status, 200);
-            assert.strictEqual(await response.text(), "Got request with body: {\"data\":\"test\"}");
-            assert.strictEqual(response.redirected, true);
-        });
-    });
-
-    describe("Cross-Origin Redirects", () => {
-        it("should follow a cross-origin redirect and apply CORS checks", async () => {
-            const server1 = new MockServer(API_URL);
-            const server2 = new MockServer(ALT_BASE_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server1, server2],
-                baseUrl: API_URL,
-            });
-
-            server1.get("/original", {
-                status: 302,
-                headers: {
-                    "Location": ALT_BASE_URL + "/redirected"
-                }
-            });
-
-            server2.get("/redirected", {
-                status: 200,
-                headers: {
-                    "Access-Control-Allow-Origin": API_URL
-                },
-                body: "Cross-origin redirected content"
-            });
-
-            const response = await fetchMocker.fetch("/original");
-            
-            assert.strictEqual(response.status, 200);
-            assert.strictEqual(await response.text(), "Cross-origin redirected content");
-            assert.strictEqual(response.redirected, true);
-        });
-
-        it("should remove the Authorization header on cross-origin redirects", async () => {
-            const server1 = new MockServer(API_URL);
-            const server2 = new MockServer(ALT_BASE_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server1, server2],
-                baseUrl: API_URL,
-            });
-
-            server1.get("/original", {
-                status: 302,
-                headers: {
-                    "Location": ALT_BASE_URL + "/redirected"
-                }
-            });
-
-            // This route expects no Authorization header
-            server2.get({
-                url: "/redirected",
-                headers: {
-                    // Just check the route without expecting any specific Authorization value
-                }
-            }, {
-                status: 200,
-                headers: {
-                    "Access-Control-Allow-Origin": API_URL
-                },
-                body: "Auth header was removed"
-            });
-
-            const response = await fetchMocker.fetch("/original", {
-                headers: {
-                    "Authorization": "Bearer token123"
-                }
-            });
-            
-            assert.strictEqual(response.status, 200);
-            assert.strictEqual(await response.text(), "Auth header was removed");
-        });
-
-        it("should throw when credentials mode is 'include' for cross-origin redirects", async () => {
-            const server1 = new MockServer(API_URL);
-            const server2 = new MockServer(ALT_BASE_URL);
-            const cookies = new CookieCredentials(API_URL);
-            const fetchMocker = new FetchMocker({
-                servers: [server1, server2],
-                baseUrl: API_URL,
-                credentials: [cookies]
-            });
-
-            cookies.setCookie({
-                name: "session",
-                value: "123"
-            });
-
-            server1.get("/original", {
-                status: 302,
-                headers: {
-                    "Location": ALT_BASE_URL + "/redirected"
-                }
-            });
-
-            server2.get("/redirected", {
-                status: 200,
-                headers: {
-                    "Access-Control-Allow-Origin": API_URL
-                },
-                body: "Cross-origin redirected content"
-            });
-
-            await assert.rejects(
-                fetchMocker.fetch("/original", { credentials: "include" }),
-                error => error instanceof TypeError && /Cross-origin redirect with credentials is not allowed/.test(error.message)
-            );
-        });
-    });
+	describe("Same-Origin Redirects", () => {
+		it("should follow a 301 redirect and change method from POST to GET", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server],
+				baseUrl: API_URL,
+			});
+
+			server.post("/original", {
+				status: 301,
+				headers: {
+					Location: "/redirected",
+				},
+			});
+
+			server.get("/redirected", {
+				status: 200,
+				body: "Redirected content",
+			});
+
+			const response = await fetchMocker.fetch("/original", {
+				method: "POST",
+				body: JSON.stringify({ data: "test" }),
+			});
+
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(await response.text(), "Redirected content");
+			assert.strictEqual(response.redirected, true);
+		});
+
+		it("should follow a 302 redirect and change method from POST to GET", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server],
+				baseUrl: API_URL,
+			});
+
+			server.post("/original", {
+				status: 302,
+				headers: {
+					Location: "/redirected",
+				},
+			});
+
+			server.get("/redirected", {
+				status: 200,
+				body: "Redirected content",
+			});
+
+			const response = await fetchMocker.fetch("/original", {
+				method: "POST",
+				body: JSON.stringify({ data: "test" }),
+			});
+
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(await response.text(), "Redirected content");
+			assert.strictEqual(response.redirected, true);
+		});
+
+		it("should follow a 303 redirect and always change method to GET", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server],
+				baseUrl: API_URL,
+			});
+
+			server.put("/original", {
+				status: 303,
+				headers: {
+					Location: "/redirected",
+				},
+			});
+
+			server.get("/redirected", {
+				status: 200,
+				body: "Redirected content",
+			});
+
+			const response = await fetchMocker.fetch("/original", {
+				method: "PUT",
+				body: JSON.stringify({ data: "test" }),
+			});
+
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(await response.text(), "Redirected content");
+			assert.strictEqual(response.redirected, true);
+		});
+
+		it("should follow a 307 redirect and preserve the original method and body", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server],
+				baseUrl: API_URL,
+			});
+
+			server.post("/original", {
+				status: 307,
+				headers: {
+					Location: "/redirected",
+				},
+			});
+
+			// Modify how we handle the body in the response handler
+			server.post(
+				{
+					url: "/redirected",
+					body: {
+						data: "test",
+					},
+				},
+				{
+					status: 200,
+					body: 'Got request with body: {"data":"test"}',
+				},
+			);
+
+			const response = await fetchMocker.fetch("/original", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ data: "test" }),
+			});
+
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(
+				await response.text(),
+				'Got request with body: {"data":"test"}',
+			);
+			assert.strictEqual(response.redirected, true);
+		});
+
+		it("should follow a 308 redirect and preserve the original method and body", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server],
+				baseUrl: API_URL,
+			});
+
+			server.post("/original", {
+				status: 308,
+				headers: {
+					Location: "/redirected",
+				},
+			});
+
+			// Modify how we handle the body in the response handler
+			server.post(
+				{
+					url: "/redirected",
+					body: {
+						data: "test",
+					},
+				},
+				{
+					status: 200,
+					body: 'Got request with body: {"data":"test"}',
+				},
+			);
+
+			const response = await fetchMocker.fetch("/original", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ data: "test" }),
+			});
+
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(
+				await response.text(),
+				'Got request with body: {"data":"test"}',
+			);
+			assert.strictEqual(response.redirected, true);
+		});
+
+		it("should not follow a redirect when redirect mode is 'error'", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server],
+				baseUrl: API_URL,
+			});
+
+			server.get("/original", {
+				status: 301,
+				headers: {
+					Location: "/redirected",
+				},
+			});
+
+			server.get("/redirected", {
+				status: 200,
+				body: "Redirected content",
+			});
+
+			await assert.rejects(
+				fetchMocker.fetch("/original", { redirect: "error" }),
+				error =>
+					error instanceof TypeError &&
+					/redirect mode being 'error'/.test(error.message),
+			);
+		});
+
+		it("should return an opaque redirect response when redirect mode is 'manual'", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server],
+				baseUrl: API_URL,
+			});
+
+			server.get("/original", {
+				status: 301,
+				headers: {
+					Location: "/redirected",
+				},
+			});
+
+			const response = await fetchMocker.fetch("/original", {
+				redirect: "manual",
+			});
+
+			assert.strictEqual(response.type, "opaqueredirect");
+			assert.strictEqual(response.status, 0);
+			assert.strictEqual(response.url, API_URL + "/original");
+		});
+
+		it("should detect and prevent redirect loops", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server],
+				baseUrl: API_URL,
+			});
+
+			server.get("/original", {
+				status: 302,
+				headers: {
+					Location: "/loop",
+				},
+			});
+
+			server.get("/loop", {
+				status: 302,
+				headers: {
+					Location: "/original",
+				},
+			});
+
+			await assert.rejects(
+				fetchMocker.fetch("/original"),
+				error =>
+					error instanceof TypeError &&
+					/Redirect loop detected/.test(error.message),
+			);
+		});
+
+		it("should throw an error when redirect limit is exceeded", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server],
+				baseUrl: API_URL,
+			});
+
+			// Setup 21 redirects (more than the 20 limit)
+			for (let i = 0; i < 21; i++) {
+				server.get(`/redirect${i}`, {
+					status: 302,
+					headers: {
+						Location: i < 20 ? `/redirect${i + 1}` : "/final",
+					},
+				});
+			}
+
+			server.get("/final", {
+				status: 200,
+				body: "Final destination",
+			});
+
+			await assert.rejects(
+				fetchMocker.fetch("/redirect0"),
+				error =>
+					error instanceof TypeError &&
+					/Too many redirects/.test(error.message),
+			);
+		});
+
+		it("should change the method to GET on 301 redirects with a body", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server],
+				baseUrl: API_URL,
+			});
+
+			server.post("/original", {
+				status: 301,
+				headers: {
+					Location: "/redirected",
+				},
+			});
+
+			server.get("/redirected", {
+				status: 200,
+				body: "Redirected content",
+			});
+
+			const response = await fetchMocker.fetch("/original", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ data: "test" }),
+			});
+
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(await response.text(), "Redirected content");
+			assert.strictEqual(response.redirected, true);
+		});
+
+		it("should change the method to GET on 302 redirects with a body", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server],
+				baseUrl: API_URL,
+			});
+			server.post("/original", {
+				status: 302,
+				headers: {
+					Location: "/redirected",
+				},
+			});
+			server.get("/redirected", {
+				status: 200,
+				body: "Redirected content",
+			});
+			const response = await fetchMocker.fetch("/original", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ data: "test" }),
+			});
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(await response.text(), "Redirected content");
+			assert.strictEqual(response.redirected, true);
+		});
+
+		it("should change the method to GET on 303 redirects with a body", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server],
+				baseUrl: API_URL,
+			});
+			server.put("/original", {
+				status: 303,
+				headers: {
+					Location: "/redirected",
+				},
+			});
+			server.get("/redirected", {
+				status: 200,
+				body: "Redirected content",
+			});
+			const response = await fetchMocker.fetch("/original", {
+				method: "PUT",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ data: "test" }),
+			});
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(await response.text(), "Redirected content");
+			assert.strictEqual(response.redirected, true);
+		});
+
+		it("should delete the content-type header on 301 redirects with a body", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server],
+				baseUrl: API_URL,
+			});
+
+			server.post("/original", {
+				status: 301,
+				headers: {
+					Location: "/redirected",
+				},
+			});
+
+			// this should not be called
+			server.get(
+				{
+					url: "/redirected",
+					headers: {
+						"Content-Type": "application/json",
+					},
+				},
+				{
+					status: 200,
+					body: "Invalid redirected content",
+				},
+			);
+
+			server.get("/redirected", {
+				status: 200,
+				body: "Redirected content",
+			});
+
+			const response = await fetchMocker.fetch("/original", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ data: "test" }),
+			});
+
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(await response.text(), "Redirected content");
+			assert.strictEqual(response.redirected, true);
+		});
+
+		it("should delete the content-type header on 303 redirects with a body", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server],
+				baseUrl: API_URL,
+			});
+
+			server.put("/original", {
+				status: 303,
+				headers: {
+					Location: "/redirected",
+				},
+			});
+
+			// this should not be called
+			server.get(
+				{
+					url: "/redirected",
+					headers: {
+						"Content-Type": "application/json",
+					},
+				},
+				{
+					status: 200,
+					body: "Invalid redirected content",
+				},
+			);
+
+			server.get("/redirected", {
+				status: 200,
+				body: "Redirected content",
+			});
+
+			const response = await fetchMocker.fetch("/original", {
+				method: "PUT",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ data: "test" }),
+			});
+
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(await response.text(), "Redirected content");
+			assert.strictEqual(response.redirected, true);
+		});
+
+		it("should not change the method to GET on 307 redirects with a body", async () => {
+			const server = new MockServer(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server],
+				baseUrl: API_URL,
+			});
+
+			server.post("/original", {
+				status: 307,
+				headers: {
+					Location: "/redirected",
+				},
+			});
+
+			// Modify how we handle the body in the response handler
+			server.post(
+				{
+					url: "/redirected",
+					body: {
+						data: "test",
+					},
+				},
+				{
+					status: 200,
+					body: 'Got request with body: {"data":"test"}',
+				},
+			);
+
+			const response = await fetchMocker.fetch("/original", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ data: "test" }),
+			});
+
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(
+				await response.text(),
+				'Got request with body: {"data":"test"}',
+			);
+			assert.strictEqual(response.redirected, true);
+		});
+	});
+
+	describe("Cross-Origin Redirects", () => {
+		it("should follow a cross-origin redirect and apply CORS checks", async () => {
+			const server1 = new MockServer(API_URL);
+			const server2 = new MockServer(ALT_BASE_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server1, server2],
+				baseUrl: API_URL,
+			});
+
+			server1.get("/original", {
+				status: 302,
+				headers: {
+					Location: ALT_BASE_URL + "/redirected",
+				},
+			});
+
+			server2.get("/redirected", {
+				status: 200,
+				headers: {
+					"Access-Control-Allow-Origin": API_URL,
+				},
+				body: "Cross-origin redirected content",
+			});
+
+			const response = await fetchMocker.fetch("/original");
+
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(
+				await response.text(),
+				"Cross-origin redirected content",
+			);
+			assert.strictEqual(response.redirected, true);
+		});
+
+		it("should remove the Authorization header on cross-origin redirects", async () => {
+			const server1 = new MockServer(API_URL);
+			const server2 = new MockServer(ALT_BASE_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server1, server2],
+				baseUrl: API_URL,
+			});
+
+			server1.get("/original", {
+				status: 302,
+				headers: {
+					Location: ALT_BASE_URL + "/redirected",
+				},
+			});
+
+			// This route expects no Authorization header
+			server2.get(
+				{
+					url: "/redirected",
+					headers: {
+						// Just check the route without expecting any specific Authorization value
+					},
+				},
+				{
+					status: 200,
+					headers: {
+						"Access-Control-Allow-Origin": API_URL,
+					},
+					body: "Auth header was removed",
+				},
+			);
+
+			const response = await fetchMocker.fetch("/original", {
+				headers: {
+					Authorization: "Bearer token123",
+				},
+			});
+
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(
+				await response.text(),
+				"Auth header was removed",
+			);
+		});
+
+		it("should throw when credentials mode is 'include' for cross-origin redirects", async () => {
+			const server1 = new MockServer(API_URL);
+			const server2 = new MockServer(ALT_BASE_URL);
+			const cookies = new CookieCredentials(API_URL);
+			const fetchMocker = new FetchMocker({
+				servers: [server1, server2],
+				baseUrl: API_URL,
+				credentials: [cookies],
+			});
+
+			cookies.setCookie({
+				name: "session",
+				value: "123",
+			});
+
+			server1.get("/original", {
+				status: 302,
+				headers: {
+					Location: ALT_BASE_URL + "/redirected",
+				},
+			});
+
+			server2.get("/redirected", {
+				status: 200,
+				headers: {
+					"Access-Control-Allow-Origin": API_URL,
+				},
+				body: "Cross-origin redirected content",
+			});
+
+			await assert.rejects(
+				fetchMocker.fetch("/original", { credentials: "include" }),
+				error =>
+					error instanceof TypeError &&
+					/Cross-origin redirect with credentials is not allowed/.test(
+						error.message,
+					),
+			);
+		});
+	});
 });


### PR DESCRIPTION
By creating the fetch function in the constructor, we allocate a new function every time the mocker is instantiated.

We can avoid this by using a field (to bind `this`) which itself delegates to a method on the prototype.