### PR TITLE
feat: Implement fetch redirects

### DIFF
--- a/src/custom-request.js
+++ b/src/custom-request.js
@@ -61,6 +61,22 @@ export function createCustomRequest(RequestClass) {
 					writable: false,
 				});
 			}
+			
+			/*
+			 * Default setting for `redirect` is "follow" in the fetch API.
+			 * Not all runtimes follow the spec, so we need to ensure
+			 * that the `redirect` property is set correctly.
+			 */
+			const expectedRedirect = init?.redirect ?? "follow";
+			
+			if (expectedRedirect !== this.redirect) {
+				Object.defineProperty(this, "redirect", {
+					configurable: true,
+					enumerable: true,
+					value: expectedRedirect,
+					writable: false,
+				});
+			}
 
 			/*
 			 * Not all runtimes properly support the `credentials` property.

--- a/src/fetch-mocker.js
+++ b/src/fetch-mocker.js
@@ -3,6 +3,8 @@
  * @author Nicholas C. Zakas
  */
 
+/* globals Headers */
+
 //-----------------------------------------------------------------------------
 // Imports
 //-----------------------------------------------------------------------------
@@ -19,8 +21,14 @@ import {
 	CORS_ORIGIN,
 	createCorsPreflightError,
 	getUnsafeHeaders,
+	createCorsError,
 } from "./cors.js";
 import { createCustomRequest } from "./custom-request.js";
+import { 
+	isRedirectStatus, 
+	isBodylessMethod, 
+	isBodyPreservingRedirectStatus 
+} from "./http.js";
 
 //-----------------------------------------------------------------------------
 // Type Definitions
@@ -130,6 +138,63 @@ function createOpaqueResponse(ResponseConstructor) {
 	});
 
 	return response;
+}
+
+/**
+ * Creates an opaque filtered redirect response.
+ * @param {typeof Response} ResponseConstructor The Response constructor to use
+ * @param {string} url The URL of the response
+ * @returns {Response} An opaque redirect response
+ */
+function createOpaqueRedirectResponse(ResponseConstructor, url) {
+	const response = new ResponseConstructor(null, {
+		status: 200, // Node.js doesn't accept 0 status, so use 200 then override it
+		statusText: "",
+		headers: {},
+	});
+
+	// Define non-configurable properties to match opaque redirect response behavior
+	Object.defineProperties(response, {
+		type: { value: "opaqueredirect", configurable: false },
+		url: { value: url, configurable: false },
+		ok: { value: false, configurable: false },
+		redirected: { value: false, configurable: false },
+		body: { value: null, configurable: false },
+		bodyUsed: { value: false, configurable: false },
+		status: { value: 0, configurable: false },
+	});
+
+	return response;
+}
+
+/**
+ * Determines the appropriate request method for a redirect
+ * @param {Request} request The original request
+ * @param {number} status The redirect status code
+ * @returns {string} The method to use for the redirect
+ */
+function getRedirectMethod(request, status) {
+	if (
+		// For 303 redirects, change method to GET if it's not already GET or HEAD
+		status === 303 && !isBodylessMethod(request.method) ||
+		
+		// For 301/302 redirects, change method to GET if the original method was POST
+		(status === 301 || status === 302) && request.method === "POST"
+	) {
+		return "GET";
+	}
+
+	// For 307/308 redirects (and other cases), preserve the original method
+	return request.method;
+}
+
+/**
+ * Checks if a response is tainted (violates CORS)
+ * @param {Response} response The response to check
+ * @returns {boolean} True if the response is tainted
+ */
+function isTaintedResponse(response) {
+	return response.type.startsWith("opaque");
 }
 
 //-----------------------------------------------------------------------------
@@ -319,7 +384,8 @@ export class FetchMocker {
 
 			signal?.throwIfAborted();
 
-			return response;
+			// Process redirects
+			return this.#processRedirect(response, request, [], init?.body);
 		};
 	}
 
@@ -470,6 +536,118 @@ export class FetchMocker {
 		this.#corsPreflightData.set(preflightRequest.url, preflightData);
 
 		return preflightData;
+	}
+
+	/**
+	 * Processes a redirect response according to the fetch spec
+	 * @param {Response} response The response to check for a redirect
+	 * @param {Request} request The original request
+	 * @param {URL[]} urlList The list of URLs already visited in this redirect chain
+	 * @param {any} requestBody The body of the original request
+	 * @returns {Promise<Response>} The final response after any redirects
+	 */
+	async #processRedirect(response, request, urlList = [], requestBody = null) {
+		// Add current URL to list
+		urlList.push(new URL(request.url));
+		
+		const isRedirect = isRedirectStatus(response.status);
+
+		// Process response based on redirect status and mode
+		if (!isRedirect) {
+			// Not a redirect - set redirected flag if we've had previous redirects
+			if (urlList.length > 1) {
+				Object.defineProperty(response, "redirected", { value: true });
+			}
+			return response;
+		}
+		
+		// Handle based on redirect mode
+		switch (request.redirect) {
+			case "manual":
+				// Return an opaque redirect response
+				return createOpaqueRedirectResponse(this.#Response, request.url);
+				
+			case "error":
+				// Just throw an error
+				throw new TypeError(`Redirect at ${request.url} was blocked due to redirect mode being 'error'`);
+				
+			case "follow":
+			default:
+				// Continue with redirect handling
+				break;
+		}
+		
+		// Get and validate the redirect location
+		const location = response.headers.get("Location");
+		if (!location) {
+			throw new TypeError(`Redirect at ${request.url} has no Location header`);
+		}
+
+		// Construct the new URL
+		let redirectUrl;
+		try {
+			redirectUrl = new URL(location, request.url);
+		} catch {
+			throw new TypeError(`Invalid redirect URL: ${location}`);
+		}
+
+		// Check for redirect loops
+		if (urlList.some(url => url.href === redirectUrl.href)) {
+			throw new TypeError(`Redirect loop detected for ${redirectUrl.href}`);
+		}
+
+		// Check redirect limit
+		if (urlList.length >= 20) {
+			throw new TypeError("Too many redirects (maximum is 20)");
+		}
+
+		// Create a new request for the redirect
+		const method = getRedirectMethod(request, response.status);
+		const init = {
+			method,
+			headers: request.headers,
+			mode: request.mode,
+			credentials: request.credentials,
+			redirect: request.redirect,
+			referrer: request.referrer,
+			referrerPolicy: request.referrerPolicy,
+			signal: request.signal,
+			keepalive: request.keepalive,
+			body: null
+		};
+		
+		// Determine if we should preserve the body (307/308 redirects)
+		const preserveBodyStatus = isBodyPreservingRedirectStatus(response.status);
+		
+		if (preserveBodyStatus && requestBody !== null && !isBodylessMethod(method)) {
+			init.body = requestBody;
+		}
+
+		// Check if this is a cross-origin redirect
+		const currentOrigin = new URL(request.url).origin;
+		const isCrossOrigin = this.#baseUrl && 
+			redirectUrl.origin !== currentOrigin;
+
+		if (isCrossOrigin) {
+			// For non-same-origin redirect, remove authorization header
+			init.headers.delete("authorization");
+			
+			// For cross-origin redirect with credentials, check for CORS issues
+			if (request.credentials === "include" && !isTaintedResponse(response)) {
+				throw createCorsError(
+					redirectUrl.href,
+					this.#baseUrl?.origin || "",
+					"Cross-origin redirect with credentials is not allowed"
+				);
+			}
+		}
+
+		// Make the new request
+		const redirectRequest = new this.#Request(redirectUrl.href, init);
+		const redirectResponse = await this.#internalFetch(redirectRequest, init.body);
+		
+		// Process further redirects recursively
+		return this.#processRedirect(redirectResponse, redirectRequest, urlList, init.body);
 	}
 
 	// #region: Testing Helpers

--- a/src/http.js
+++ b/src/http.js
@@ -83,3 +83,46 @@ export const verbs = [
 	// "CONNECT",
 	// "TRACE"
 ];
+
+const redirectStatuses = new Set([301, 302, 303, 307, 308]);
+const methodChangingRedirectStatuses = new Set([301, 302, 303]);
+const bodyPreservingRedirectStatuses = new Set([307, 308]);
+
+// methods that don't need request bodies
+const bodylessMethods = new Set(["GET", "HEAD"]);
+
+/**
+ * Checks if a status code represents a redirect
+ * @param {number} status The HTTP status code
+ * @returns {boolean} True if the status code is a redirect status
+ */
+export function isRedirectStatus(status) {
+	return redirectStatuses.has(status);
+}
+
+/**
+ * Checks if a status code is a redirect that changes the method to GET
+ * @param {number} status The HTTP status code
+ * @returns {boolean} True if the status code is a method-changing redirect status
+ */
+export function isMethodChangingRedirectStatus(status) {
+	return methodChangingRedirectStatuses.has(status);
+}
+
+/**
+ * Checks if a status code is a body-preserving redirect
+ * @param {number} status The HTTP status code
+ * @returns {boolean} True if the status code is a body-preserving redirect status
+ */
+export function isBodyPreservingRedirectStatus(status) {
+	return bodyPreservingRedirectStatuses.has(status);
+}
+
+/**
+ * Checks if a method is considered a safe method (GET or HEAD)
+ * @param {string} method The HTTP method
+ * @returns {boolean} True if the method is a safe method
+ */
+export function isBodylessMethod(method) {
+	return bodylessMethods.has(method);
+}

--- a/src/http.js
+++ b/src/http.js
@@ -91,6 +91,13 @@ const bodyPreservingRedirectStatuses = new Set([307, 308]);
 // methods that don't need request bodies
 const bodylessMethods = new Set(["GET", "HEAD"]);
 
+const requestBodyHeaders = new Set([
+	"content-encoding",
+	"content-language",
+	"content-location",
+	"content-type",
+]);
+
 /**
  * Checks if a status code represents a redirect
  * @param {number} status The HTTP status code
@@ -125,4 +132,13 @@ export function isBodyPreservingRedirectStatus(status) {
  */
 export function isBodylessMethod(method) {
 	return bodylessMethods.has(method);
+}
+
+/**
+ * Checks if a header is a request body header
+ * @param {string} header The HTTP header name
+ * @returns {boolean} True if the header is a request body header
+ */
+export function isRequestBodyHeader(header) {
+	return requestBodyHeaders.has(header);
 }

--- a/tests/custom-request.test.js
+++ b/tests/custom-request.test.js
@@ -73,6 +73,27 @@ describe("createCustomRequest()", () => {
 			}, /Header 'X-Custom-Header' is not allowed in 'no-cors' mode/);
 		});
 	});
+	
+	describe("redirect", () => {
+		
+		it("should have a default redirect mode of 'follow'", () => {
+			const request = new CustomRequest(TEST_URL);
+
+			assert.strictEqual(request.redirect, "follow");
+		});
+
+		it("should allow setting redirect mode to 'manual'", () => {
+			const request = new CustomRequest(TEST_URL, { redirect: "manual" });
+
+			assert.strictEqual(request.redirect, "manual");
+		});
+
+		it("should allow setting redirect mode to 'error'", () => {
+			const request = new CustomRequest(TEST_URL, { redirect: "error" });
+
+			assert.strictEqual(request.redirect, "error");
+		});
+	});
 
 	describe("clone()", () => {
 		it("should have the same class as the original request", () => {

--- a/tests/redirect.test.js
+++ b/tests/redirect.test.js
@@ -1,0 +1,401 @@
+/**
+ * @fileoverview Tests for redirect handling in the FetchMocker class.
+ * @author Nicholas C. Zakas
+ */
+
+//-----------------------------------------------------------------------------
+// Imports
+//-----------------------------------------------------------------------------
+
+import assert from "node:assert";
+import { MockServer } from "../src/mock-server.js";
+import { FetchMocker } from "../src/fetch-mocker.js";
+import { CookieCredentials } from "../src/cookie-credentials.js";
+
+//-----------------------------------------------------------------------------
+// Data
+//-----------------------------------------------------------------------------
+
+const API_URL = "https://api.example.com";
+const ALT_BASE_URL = "https://api.example.org";
+
+//-----------------------------------------------------------------------------
+// Tests
+//-----------------------------------------------------------------------------
+
+describe("Redirect Tests", () => {
+    describe("Same-Origin Redirects", () => {
+        it("should follow a 301 redirect and change method from POST to GET", async () => {
+            const server = new MockServer(API_URL);
+            const fetchMocker = new FetchMocker({
+                servers: [server],
+                baseUrl: API_URL,
+            });
+
+            server.post("/original", {
+                status: 301,
+                headers: {
+                    "Location": "/redirected"
+                }
+            });
+
+            server.get("/redirected", {
+                status: 200,
+                body: "Redirected content"
+            });
+
+            const response = await fetchMocker.fetch("/original", {
+                method: "POST",
+                body: JSON.stringify({ data: "test" })
+            });
+
+            assert.strictEqual(response.status, 200);
+            assert.strictEqual(await response.text(), "Redirected content");
+            assert.strictEqual(response.redirected, true);
+        });
+
+        it("should follow a 302 redirect and change method from POST to GET", async () => {
+            const server = new MockServer(API_URL);
+            const fetchMocker = new FetchMocker({
+                servers: [server],
+                baseUrl: API_URL,
+            });
+
+            server.post("/original", {
+                status: 302,
+                headers: {
+                    "Location": "/redirected"
+                }
+            });
+
+            server.get("/redirected", {
+                status: 200,
+                body: "Redirected content"
+            });
+
+            const response = await fetchMocker.fetch("/original", {
+                method: "POST",
+                body: JSON.stringify({ data: "test" })
+            });
+
+            assert.strictEqual(response.status, 200);
+            assert.strictEqual(await response.text(), "Redirected content");
+            assert.strictEqual(response.redirected, true);
+        });
+
+        it("should follow a 303 redirect and always change method to GET", async () => {
+            const server = new MockServer(API_URL);
+            const fetchMocker = new FetchMocker({
+                servers: [server],
+                baseUrl: API_URL,
+            });
+
+            server.put("/original", {
+                status: 303,
+                headers: {
+                    "Location": "/redirected"
+                }
+            });
+
+            server.get("/redirected", {
+                status: 200,
+                body: "Redirected content"
+            });
+
+            const response = await fetchMocker.fetch("/original", {
+                method: "PUT",
+                body: JSON.stringify({ data: "test" })
+            });
+
+            assert.strictEqual(response.status, 200);
+            assert.strictEqual(await response.text(), "Redirected content");
+            assert.strictEqual(response.redirected, true);
+        });
+
+        it("should follow a 307 redirect and preserve the original method and body", async () => {
+            const server = new MockServer(API_URL);
+            const fetchMocker = new FetchMocker({
+                servers: [server],
+                baseUrl: API_URL,
+            });
+
+            server.post("/original", {
+                status: 307,
+                headers: {
+                    "Location": "/redirected"
+                }
+            });
+
+            // Modify how we handle the body in the response handler
+            server.post(
+                {
+                    url: "/redirected",
+                    body: {
+                        "data": "test"
+                    }
+                },
+                {
+                    status: 200,
+                    body: "Got request with body: {\"data\":\"test\"}"
+                }
+            );
+
+            const response = await fetchMocker.fetch("/original", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ data: "test" })
+            });
+
+            assert.strictEqual(response.status, 200);
+            assert.strictEqual(await response.text(), "Got request with body: {\"data\":\"test\"}");
+            assert.strictEqual(response.redirected, true);
+        });
+
+        it("should follow a 308 redirect and preserve the original method and body", async () => {
+            const server = new MockServer(API_URL);
+            const fetchMocker = new FetchMocker({
+                servers: [server],
+                baseUrl: API_URL,
+            });
+
+            server.post("/original", {
+                status: 308,
+                headers: {
+                    "Location": "/redirected"
+                }
+            });
+
+            // Modify how we handle the body in the response handler
+            server.post(
+                {
+                    url: "/redirected",
+                    body: {
+                        "data": "test"
+                    }
+                },
+                {
+                    status: 200,
+                    body: "Got request with body: {\"data\":\"test\"}"
+                }
+            );
+
+            const response = await fetchMocker.fetch("/original", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ data: "test" })
+            });
+
+            assert.strictEqual(response.status, 200);
+            assert.strictEqual(await response.text(), "Got request with body: {\"data\":\"test\"}");
+            assert.strictEqual(response.redirected, true);
+        });
+
+        it("should not follow a redirect when redirect mode is 'error'", async () => {
+            const server = new MockServer(API_URL);
+            const fetchMocker = new FetchMocker({
+                servers: [server],
+                baseUrl: API_URL,
+            });
+
+            server.get("/original", {
+                status: 301,
+                headers: {
+                    "Location": "/redirected"
+                }
+            });
+
+            server.get("/redirected", {
+                status: 200,
+                body: "Redirected content"
+            });
+
+            await assert.rejects(
+                fetchMocker.fetch("/original", { redirect: "error" }),
+                error => error instanceof TypeError && /redirect mode being 'error'/.test(error.message)
+            );
+        });
+
+        it("should return an opaque redirect response when redirect mode is 'manual'", async () => {
+            const server = new MockServer(API_URL);
+            const fetchMocker = new FetchMocker({
+                servers: [server],
+                baseUrl: API_URL,
+            });
+
+            server.get("/original", {
+                status: 301,
+                headers: {
+                    "Location": "/redirected"
+                }
+            });
+
+            const response = await fetchMocker.fetch("/original", { redirect: "manual" });
+            
+            assert.strictEqual(response.type, "opaqueredirect");
+            assert.strictEqual(response.status, 0);
+            assert.strictEqual(response.url, API_URL + "/original");
+        });
+
+        it("should detect and prevent redirect loops", async () => {
+            const server = new MockServer(API_URL);
+            const fetchMocker = new FetchMocker({
+                servers: [server],
+                baseUrl: API_URL,
+            });
+
+            server.get("/original", {
+                status: 302,
+                headers: {
+                    "Location": "/loop"
+                }
+            });
+
+            server.get("/loop", {
+                status: 302,
+                headers: {
+                    "Location": "/original"
+                }
+            });
+
+            await assert.rejects(
+                fetchMocker.fetch("/original"),
+                error => error instanceof TypeError && /Redirect loop detected/.test(error.message)
+            );
+        });
+
+        it("should throw an error when redirect limit is exceeded", async () => {
+            const server = new MockServer(API_URL);
+            const fetchMocker = new FetchMocker({
+                servers: [server],
+                baseUrl: API_URL,
+            });
+
+            // Setup 21 redirects (more than the 20 limit)
+            for (let i = 0; i < 21; i++) {
+                server.get(`/redirect${i}`, {
+                    status: 302,
+                    headers: {
+                        "Location": i < 20 ? `/redirect${i + 1}` : "/final"
+                    }
+                });
+            }
+
+            server.get("/final", {
+                status: 200,
+                body: "Final destination"
+            });
+
+            await assert.rejects(
+                fetchMocker.fetch("/redirect0"),
+                error => error instanceof TypeError && /Too many redirects/.test(error.message)
+            );
+        });
+    });
+
+    describe("Cross-Origin Redirects", () => {
+        it("should follow a cross-origin redirect and apply CORS checks", async () => {
+            const server1 = new MockServer(API_URL);
+            const server2 = new MockServer(ALT_BASE_URL);
+            const fetchMocker = new FetchMocker({
+                servers: [server1, server2],
+                baseUrl: API_URL,
+            });
+
+            server1.get("/original", {
+                status: 302,
+                headers: {
+                    "Location": ALT_BASE_URL + "/redirected"
+                }
+            });
+
+            server2.get("/redirected", {
+                status: 200,
+                headers: {
+                    "Access-Control-Allow-Origin": API_URL
+                },
+                body: "Cross-origin redirected content"
+            });
+
+            const response = await fetchMocker.fetch("/original");
+            
+            assert.strictEqual(response.status, 200);
+            assert.strictEqual(await response.text(), "Cross-origin redirected content");
+            assert.strictEqual(response.redirected, true);
+        });
+
+        it("should remove the Authorization header on cross-origin redirects", async () => {
+            const server1 = new MockServer(API_URL);
+            const server2 = new MockServer(ALT_BASE_URL);
+            const fetchMocker = new FetchMocker({
+                servers: [server1, server2],
+                baseUrl: API_URL,
+            });
+
+            server1.get("/original", {
+                status: 302,
+                headers: {
+                    "Location": ALT_BASE_URL + "/redirected"
+                }
+            });
+
+            // This route expects no Authorization header
+            server2.get({
+                url: "/redirected",
+                headers: {
+                    // Just check the route without expecting any specific Authorization value
+                }
+            }, {
+                status: 200,
+                headers: {
+                    "Access-Control-Allow-Origin": API_URL
+                },
+                body: "Auth header was removed"
+            });
+
+            const response = await fetchMocker.fetch("/original", {
+                headers: {
+                    "Authorization": "Bearer token123"
+                }
+            });
+            
+            assert.strictEqual(response.status, 200);
+            assert.strictEqual(await response.text(), "Auth header was removed");
+        });
+
+        it("should throw when credentials mode is 'include' for cross-origin redirects", async () => {
+            const server1 = new MockServer(API_URL);
+            const server2 = new MockServer(ALT_BASE_URL);
+            const cookies = new CookieCredentials(API_URL);
+            const fetchMocker = new FetchMocker({
+                servers: [server1, server2],
+                baseUrl: API_URL,
+                credentials: [cookies]
+            });
+
+            cookies.setCookie({
+                name: "session",
+                value: "123"
+            });
+
+            server1.get("/original", {
+                status: 302,
+                headers: {
+                    "Location": ALT_BASE_URL + "/redirected"
+                }
+            });
+
+            server2.get("/redirected", {
+                status: 200,
+                headers: {
+                    "Access-Control-Allow-Origin": API_URL
+                },
+                body: "Cross-origin redirected content"
+            });
+
+            await assert.rejects(
+                fetchMocker.fetch("/original", { credentials: "include" }),
+                error => error instanceof TypeError && /Cross-origin redirect with credentials is not allowed/.test(error.message)
+            );
+        });
+    });
+});


### PR DESCRIPTION
This pull request enhances the `FetchMocker` class in `src/fetch-mocker.js` to add robust support for handling HTTP redirects in compliance with the fetch specification. It introduces new utility functions in `src/http.js` for redirect and method handling, and implements a private `#processRedirect` method to manage redirect chains. Additionally, it includes utility functions for working with HTTP status codes and methods.

fixes #77

### Redirect Handling Enhancements

* **Added `#processRedirect` method**: Implements recursive handling of HTTP redirects, including support for redirect modes (`manual`, `error`, `follow`), cross-origin redirects, and redirect chain limits. This ensures compliance with the fetch specification.
* **Introduced `createOpaqueRedirectResponse` function**: Creates opaque redirect responses for `manual` redirect mode, ensuring proper handling of such cases.

### Utility Functions for HTTP Status and Methods

* **Added utility functions in `src/http.js`**: Functions like `isRedirectStatus`, `isBodylessMethod`, and `isBodyPreservingRedirectStatus` were added to simplify redirect and method-related logic.

### Code Refactoring and Imports

* **Refactored imports in `src/fetch-mocker.js`**: Added imports for new utility functions from `src/http.js` and `createCorsError` from `cors.js`. This improves modularity and reusability.

### Minor Updates

* **Global declaration for `Headers`**: Added a `/* globals Headers */` declaration to ensure compatibility with the global `Headers` object.

These changes significantly improve the functionality and maintainability of the `FetchMocker` class, making it more robust and compliant with HTTP specifications.