### PR TITLE
feat: Implement SameSite for cookies

### DIFF
--- a/docs/src/content/docs/fetch-mockers/mocking-browser-requests.mdx
+++ b/docs/src/content/docs/fetch-mockers/mocking-browser-requests.mdx
@@ -114,13 +114,14 @@ credentials.setCookie({
     name: "sessionId",
     value: "abc123",
     path: "/admin",      // defaults to "/"
+    sameSite: "none",    // defaults to "lax"
     secure: true,        // defaults to false
     httpOnly: true       // defaults to false
 });
 ```
 
 <Aside type="note">
-	Real cookies also allow you to specify an expiration date and the `HttpOnly` flag, but neither is useful for testing purposes and so are not supported.
+	Real cookies also allow you to specify an expiration date but that's not useful for testing purposes and so is not supported.
 </Aside>
 
 <Aside type="caution">
@@ -202,6 +203,7 @@ Cookies are included in requests based on these rules:
 1. The request domain must match or be a subdomain of the cookie's domain
 2. The request path must match or be under the cookie's path
 3. For secure cookies, the request must use HTTPS
+4. The request must match the cookie's `sameSite` policy (if set)
 
 For example:
 


### PR DESCRIPTION
This pull request introduces support for the `SameSite` attribute in cookies, making Mentoss work more similarly to browsers for better testing of CORS requests.

### Enhancements to Cookie Handling:

* Added support for the `SameSite` attribute in the `Cookie` class, with valid values being `"strict"`, `"lax"`, and `"none"`. The default is set to `"lax"`. (`[[1]](diffhunk://#diff-45b6751f6740be1d29980f701f3f438f5211ecde42697d68aecc6ce6537fa45bR32-R40)`, `[[2]](diffhunk://#diff-45b6751f6740be1d29980f701f3f438f5211ecde42697d68aecc6ce6537fa45bR115-R120)`, `[[3]](diffhunk://#diff-45b6751f6740be1d29980f701f3f438f5211ecde42697d68aecc6ce6537fa45bR130)`, `[[4]](diffhunk://#diff-45b6751f6740be1d29980f701f3f438f5211ecde42697d68aecc6ce6537fa45bR139)`, `[[5]](diffhunk://#diff-45b6751f6740be1d29980f701f3f438f5211ecde42697d68aecc6ce6537fa45bR257-R260)`)
* Introduced the `assertValidSameSite` function to validate `SameSite` values and enforce the requirement that `SameSite=None` must be used with the `Secure` flag. (`[[1]](diffhunk://#diff-45b6751f6740be1d29980f701f3f438f5211ecde42697d68aecc6ce6537fa45bR57-R73)`, `[[2]](diffhunk://#diff-45b6751f6740be1d29980f701f3f438f5211ecde42697d68aecc6ce6537fa45bR151-R159)`)
* Updated the `isCredentialForRequest` method to respect the `SameSite` attribute when determining if a cookie should be included in a request. (`[src/cookie-credentials.jsL145-R231](diffhunk://#diff-45b6751f6740be1d29980f701f3f438f5211ecde42697d68aecc6ce6537fa45bL145-R231)`)

### Documentation Updates:

* Updated documentation to include the new `SameSite` attribute in cookie examples and explain its behavior in requests. (`[[1]](diffhunk://#diff-77d410b848bb00a246be54bb817b228940042a856393b3466c0156b68f9b21f4R117-R124)`, `[[2]](diffhunk://#diff-77d410b848bb00a246be54bb817b228940042a856393b3466c0156b68f9b21f4R206)`)

### Test Coverage:

* Added unit tests to verify correct behavior of the `SameSite` attribute, including validation logic and request inclusion rules for different `SameSite` values. (`[[1]](diffhunk://#diff-15e88dae529754edfa9eb84a59155a190204ea75dddab184aef6a0b3786f3d76R154-R207)`, `[[2]](diffhunk://#diff-15e88dae529754edfa9eb84a59155a190204ea75dddab184aef6a0b3786f3d76R440-R519)`)