### PR TITLE
refactor: Create NoRouteMatchedError

### DIFF
--- a/src/fetch-mocker.js
+++ b/src/fetch-mocker.js
@@ -9,7 +9,7 @@
 // Imports
 //-----------------------------------------------------------------------------
 
-import { stringifyRequest } from "./util.js";
+import { NoRouteMatchedError } from "./util.js";
 import {
 	isCorsSimpleRequest,
 	CorsPreflightData,
@@ -43,38 +43,6 @@ import {
 //-----------------------------------------------------------------------------
 // Helpers
 //-----------------------------------------------------------------------------
-
-/**
- * Formats a message for when no route is matched.
- * @param {Request} request The request that wasn't matched.
- * @param {string|any|FormData|null} body The body of the request.
- * @param {Trace[]} traces The traces from the servers.
- * @returns {string} The formatted message.
- */
-function formatNoRouteMatchedMessage(request, body, traces) {
-	return `No route matched for ${request.method} ${request.url}.
-
-Full Request:
-
-${stringifyRequest(request, body)}
-
-${
-	traces.length === 0
-		? "No partial matches found."
-		: "Partial matches:\n\n" +
-			traces
-				.map(trace => {
-					let traceMessage = `${trace.title}:`;
-
-					trace.messages.forEach(message => {
-						traceMessage += `\n  ${message}`;
-					});
-
-					return traceMessage;
-				})
-				.join("\n\n")
-}`;
-}
 
 /**
  * Creates a base URL from a URL or string. This is also validates
@@ -451,9 +419,7 @@ export class FetchMocker {
 		);
 
 		// throw an error saying the route wasn't matched
-		throw new Error(
-			formatNoRouteMatchedMessage(request, body, possibleTraces),
-		);
+		throw new NoRouteMatchedError(request, body, possibleTraces);
 	}
 
 	/**

--- a/src/util.js
+++ b/src/util.js
@@ -71,6 +71,48 @@ export class URLParseError extends Error {
 }
 
 /**
+ * Represents an error that occurs when no route matched a request.
+ * @extends {Error}
+ */
+export class NoRouteMatchedError extends Error {
+	/**
+	 * Creates a new NoRouteMatchedError instance.
+	 * @param {Request} request The request that wasn't matched.
+	 * @param {string|any|FormData|null} body The body of the request.
+	 * @param {Array<{title: string, messages: Array<string>}>} traces The traces from the servers.
+	 */
+	constructor(request, body, traces) {
+		const message = `No route matched for ${request.method} ${request.url}.
+
+Full Request:
+
+${stringifyRequest(request, body)}
+
+${
+	traces.length === 0
+		? "No partial matches found."
+		: "Partial matches:\n\n" +
+			traces
+				.map(trace => {
+					let traceMessage = `${trace.title}:`;
+
+					trace.messages.forEach(message => {
+						traceMessage += `\n  ${message}`;
+					});
+
+					return traceMessage;
+				})
+				.join("\n\n")
+}`;
+		super(message);
+		this.name = "NoRouteMatchedError";
+		this.request = request;
+		this.body = body;
+		this.traces = traces;
+	}
+}
+
+/**
  * Parses a URL and returns a URL object. This is used instead
  * of the URL constructor to provide a standard error message,
  * because different runtimes use different messages.

--- a/tests/fetch-mocker.test.js
+++ b/tests/fetch-mocker.test.js
@@ -255,7 +255,7 @@ describe("FetchMocker", () => {
 		});
 
 		await assert.rejects(fetchMocker.fetch(API_URL + "/goodbye"), {
-			name: "Error",
+			name: "NoRouteMatchedError",
 			message: NO_ROUTE_MATCHED_NO_PARTIAL_MATCHES,
 		});
 	});
@@ -283,7 +283,7 @@ describe("FetchMocker", () => {
 		);
 
 		await assert.rejects(fetchMocker.fetch(API_URL + "/user/settings"), {
-			name: "Error",
+			name: "NoRouteMatchedError",
 			message: NO_ROUTE_MATCHED_TWO_PARTIAL_MATCHES,
 		});
 	});
@@ -321,7 +321,7 @@ describe("FetchMocker", () => {
 				body: JSON.stringify({ name: "value" }),
 			}),
 			{
-				name: "Error",
+				name: "NoRouteMatchedError",
 				message: NO_ROUTE_MATCHED_HEADERS_BODY,
 			},
 		);


### PR DESCRIPTION
This pull request refactors error handling in the `FetchMocker` module by introducing a new `NoRouteMatchedError` class to replace the previous inline error message formatting. It also updates the corresponding tests to validate the new error class.

### Refactoring of error handling:

* Replaced the `formatNoRouteMatchedMessage` function in `src/fetch-mocker.js` with a new `NoRouteMatchedError` class in `src/util.js`. This class encapsulates error details, including the request, body, and traces, and formats the error message. (`[[1]](diffhunk://#diff-09d3018654f9d696c2ce0a5938eb9b5dd6adb822704efafcbfde8b6342f246c5L12-R12)`, `[[2]](diffhunk://#diff-09d3018654f9d696c2ce0a5938eb9b5dd6adb822704efafcbfde8b6342f246c5L47-L78)`, `[[3]](diffhunk://#diff-9c0ec1b0a889e599f3ff81590864dd9dc65684a86b41f1da75acc53fafed12e3R73-R114)`)

* Updated the `FetchMocker` class to throw `NoRouteMatchedError` instead of a generic `Error` with a formatted message. (`[src/fetch-mocker.jsL454-R422](diffhunk://#diff-09d3018654f9d696c2ce0a5938eb9b5dd6adb822704efafcbfde8b6342f246c5L454-R422)`)

### Test updates:

* Modified existing tests in `tests/fetch-mocker.test.js` to expect `NoRouteMatchedError` instead of a generic `Error`. (`[[1]](diffhunk://#diff-c7749aa975a360a952d495ce66db5a38c09de5fa882d6cf00f2a86949208c1b9L258-R258)`, `[[2]](diffhunk://#diff-c7749aa975a360a952d495ce66db5a38c09de5fa882d6cf00f2a86949208c1b9L286-R286)`, `[[3]](diffhunk://#diff-c7749aa975a360a952d495ce66db5a38c09de5fa882d6cf00f2a86949208c1b9L324-R324)`)

* Added new unit tests in `tests/util.test.js` to verify the behavior of `NoRouteMatchedError`, including scenarios for no partial matches, partial matches, and requests with a body. (`[[1]](diffhunk://#diff-32df2daa2e49864e615222ac9ef9027103da6d8fb186c7521f6d3d8fd01ff6c5L13-R13)`, `[[2]](diffhunk://#diff-32df2daa2e49864e615222ac9ef9027103da6d8fb186c7521f6d3d8fd01ff6c5R188-R270)`)