### PR TITLE
feat: add global mock helperts to MockAgent

### DIFF
--- a/src/mock-agent.js
+++ b/src/mock-agent.js
@@ -155,6 +155,12 @@ export class MockAgent {
 	#Request;
 
 	/**
+	 * The original dispacher when overwriting the global fetch.
+	 * @type {unknown}
+	 */
+	#originalDispatcher;
+
+	/**
 	 * Creates a new instance.
 	 * @param {MockAgentOptions} options Options for the instance.
 	 */
@@ -394,6 +400,28 @@ export class MockAgent {
 	 */
 	clearAll() {
 		this.#servers.forEach(server => server.clear());
+	}
+
+	/**
+	 * Mocks the global fetch function.
+	 * @returns {void}
+	 */
+	mockGlobal() {
+		if (!this.#originalDispatcher) {
+			this.#originalDispatcher = globalThis[Symbol.for('undici.globalDispatcher.1')];
+			globalThis[Symbol.for('undici.globalDispatcher.1')] = this;
+		}
+	}
+
+	/**
+	 * Unmocks the global fetch function.
+	 * @returns {void}
+	 */
+	unmockGlobal() {
+		if(this.#originalDispatcher) {
+			globalThis[Symbol.for('undici.globalDispatcher.1')] = this.#originalDispatcher;
+			this.#originalDispatcher = undefined;
+		}
 	}
 
 	// #endregion: Testing Helpers

--- a/tests/mock-agent.test.js
+++ b/tests/mock-agent.test.js
@@ -664,4 +664,44 @@ describe("MockAgent", () => {
 			assert.strictEqual(agent.called(`${API_URL}/hello`), false);
 		});
 	});
+
+	describe("mockGlobal", () => {
+			it("should replace global fetch", () => {
+				const server = new MockServer(API_URL);
+				const mockAgent = new MockAgent({
+					servers: [server],
+				});
+	
+				const originalFetch = globalThis[Symbol.for('undici.globalDispatcher.1')];
+	
+				try {
+					mockAgent.mockGlobal();
+	
+					assert.strictEqual(globalThis[Symbol.for('undici.globalDispatcher.1')], mockAgent);
+				} finally {
+					globalThis[Symbol.for('undici.globalDispatcher.1')] = originalFetch;
+				}
+			});
+		});
+	
+		describe("unmockGlobal", () => {
+			it("should restore global fetch", () => {
+				const server = new MockServer(API_URL);
+				const mockAgent = new MockAgent({
+					servers: [server],
+				});
+	
+				const originalFetch = globalThis[Symbol.for('undici.globalDispatcher.1')];
+	
+				try {
+					mockAgent.mockGlobal();
+					mockAgent.unmockGlobal();
+	
+					assert.strictEqual(globalThis[Symbol.for('undici.globalDispatcher.1')], originalFetch);
+				} finally {
+					globalThis[Symbol.for('undici.globalDispatcher.1')] = originalFetch;
+				}
+			});
+		});
+	
 });


### PR DESCRIPTION
This PR adds helpers `mockGlobal` and `unmockGlobal` to the `MockAgent`.

See https://github.com/nodejs/undici/discussions/2167#discussioncomment-6265039 for clarification on the method used.